### PR TITLE
Add artwork and logo support for additional sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
 - You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)
 - Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/pSpitzner/beets-flask/pull/277)
+- Added external artwork support for Bandcamp, Discogs, and Beatport in the `/art` backend proxy flow [#274](https://github.com/pSpitzner/beets-flask/issues/274)
+- Added backend-proxied external artwork resolution for `/art` to reduce CORS-related cover-loading failures [#275](https://github.com/pSpitzner/beets-flask/issues/275)
+- Added source logos for Spotify, Bandcamp, Discogs, and Beatport in `SourceTypeIcon` using `simple-icons`
+- Added integration test coverage for art-proxy behavior in `backend/tests/integration/test_routes/test_art_preview.py`
 
 ### Fixed
 
@@ -35,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
 - Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
 - Fixed an issue with timestamps shown in the library view [#289](https://github.com/pSpitzner/beets-flask/issues/289)
+- External artwork now returns `404` when no image is available, so missing covers reliably trigger the existing frontend fallback path
+- Updated external artwork loading in the frontend to validate `/art` response status before treating it as success and throw `HTTPError` on non-OK responses
+- Improved missing-artwork behavior so failed external art requests no longer leave blank image states
 
 ### Other (dev)
 

--- a/backend/beets_flask/server/routes/art_preview.py
+++ b/backend/beets_flask/server/routes/art_preview.py
@@ -4,12 +4,20 @@ Allows fetching of art via different ids. At the moment we support:
 - Spotify album ids (if spotify plugin is enabled)
 """
 
+import asyncio
+import inspect
+import json
 import os
-from urllib.parse import quote_plus
+import re
+import time
+from urllib.parse import quote_plus, urlparse
 
 import aiohttp
-from quart import Blueprint, jsonify, redirect, request, url_for
+from beets.plugins import find_plugins
+from confuse import ConfigError
+from quart import Blueprint, jsonify, make_response, redirect, request, url_for
 
+from beets_flask.config import get_config
 from beets_flask.logger import log
 from beets_flask.utility import AUDIO_EXTENSIONS
 
@@ -18,23 +26,31 @@ art_blueprint = Blueprint("art", __name__, url_prefix="/art")
 
 @art_blueprint.route("", methods=["GET"])
 async def redirect_external_art():
-    """Get Spotify album art."""
+    """Resolve cover art for external release URLs used in preview mode."""
 
     # Check that url query param is set
     url = request.args.get("url")
     if not url:
-        return jsonify({"error": "url query param is required."}), 400
+        return jsonify({"message": "url query param is required."}), 400
 
-    # Check that url is a valid spotify url
+    # Check that url is a valid supported source url
     redirect_url: str | None = None
     if "spotify" in url:
         redirect_url = await get_spotify_art(url)
     elif "musicbrainz" in url:
         redirect_url = await get_musicbrainz_art(url)
+    elif "bandcamp" in url:
+        redirect_url = await get_bandcamp_art(url)
+    elif "discogs" in url:
+        redirect_url = await get_discogs_art(url)
+    elif "beatport" in url:
+        redirect_url = await get_beatport_art(url)
     elif url.startswith("file://"):
         return await get_folder_art(url)
 
     if redirect_url:
+        if redirect_url.startswith("http://") or redirect_url.startswith("https://"):
+            return await _proxy_remote_image(redirect_url)
         return redirect(redirect_url, code=302)
     else:
         return jsonify({"error": "No art found."}), 404
@@ -48,16 +64,19 @@ async def get_spotify_art(url: str) -> str | None:
     Returns the url the the art.
     """
     print(f"https://embed.spotify.com/oembed?url={quote_plus(url)}")
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            f"https://embed.spotify.com/oembed?url={quote_plus(url)}"
-        ) as response:
-            if response.status == 200:
-                data = await response.json()
-                return data.get("thumbnail_url")
-            else:
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"https://embed.spotify.com/oembed?url={quote_plus(url)}"
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("thumbnail_url")
                 log.error(f"Error fetching Spotify art: {response.status}")
                 return None
+    except aiohttp.ClientError as err:
+        log.error(f"Error fetching Spotify art for {url}: {err}")
+        return None
 
 
 async def get_musicbrainz_art(url: str) -> str | None:
@@ -68,12 +87,272 @@ async def get_musicbrainz_art(url: str) -> str | None:
     Returns the url the the art.
     """
 
-    # Extract the release id from the url
+    # Extract the release id from the url.
     # musicbrainz urls look like this:
     # https://musicbrainz.org/release/2b5f7e4d-2a1c-4f6d-8a0c-7b8b9e3a1f3f
-    release_id = url.split("/")[-1]
+    match = re.search(r"musicbrainz\.org/release/([0-9a-fA-F-]{36})", url)
+    if not match:
+        return None
 
-    return f"https://coverartarchive.org/release/{release_id}/front-250"
+    return f"https://coverartarchive.org/release/{match.group(1)}/front-250"
+
+
+async def _proxy_remote_image(url: str):
+    """Fetch and proxy an image URL from the server-side."""
+    attempted: list[str] = [url]
+    if "coverartarchive.org" in url and "front-250" in url:
+        attempted.append(url.replace("front-250", "front"))
+
+    for candidate in attempted:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(candidate) as response:
+                    if response.status == 200:
+                        content_type = response.headers.get(
+                            "Content-Type", "image/jpeg"
+                        )
+                        if not content_type.startswith("image/"):
+                            continue
+
+                        payload = await response.read()
+                        resp = await make_response(payload)
+                        resp.headers["Content-Type"] = content_type
+                        resp.headers["Cache-Control"] = "public, max-age=86400"
+                        return resp
+        except Exception as err:
+            log.error(f"Error proxying image {candidate}: {err}")
+            return jsonify({"message": "No artwork found."}), 404
+
+    return jsonify({"message": "No artwork found."}), 404
+
+
+async def get_bandcamp_art(url: str) -> str | None:
+    """Resolve cover art for Bandcamp release URLs.
+
+    Bandcamp artwork is extracted from the release's JSON-LD metadata in the
+    page HTML. This implementation follows the approach used in the beetcamp
+    project.
+
+    See https://github.com/snejus/beetcamp/blob/main/beetcamp/metaguru.py
+
+    Returns the url the the art.
+    """
+
+    # For size formats, see https://stackoverflow.com/a/69481878
+    bandcamp_art_format = 4
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                headers={"User-Agent": "Beets-Flask/1.0"},
+            ) as response:
+                if response.status != 200:
+                    log.error(
+                        f"Error fetching Bandcamp art for {url}: {response.status}"
+                    )
+                    return None
+
+                html = await response.text()
+
+        match = re.search(r'.*"@id".*', html)
+        if not match:
+            return None
+
+        data = json.loads(match.group(0).strip())
+        meta = data[0] if isinstance(data, list) else data
+        target_meta = meta.get("inAlbum") or meta
+        image = target_meta.get("image")
+
+        if isinstance(image, list) and len(image) > 0:
+            image = image[0]
+        if image:
+            return re.sub(
+                r"(?<=bcbits\.com/img/a)(\d+)_\d+(?=\.jpg(?:[?#]|$))",
+                rf"\1_{bandcamp_art_format}",
+                str(image),
+            )
+
+        return None
+    except (
+        aiohttp.ClientError,
+        json.JSONDecodeError,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as err:
+        log.error(f"Error parsing Bandcamp art for {url}: {err}")
+        return None
+
+
+async def get_discogs_art(url: str) -> str | None:
+    """Resolve cover art for Discogs release URLs using the beets token.
+
+    See https://github.com/beetbox/beets/blob/master/beetsplug/discogs/__init__.py
+
+    Returns the url the the art.
+    """
+
+    match = re.search(r"discogs\.com/(?:[^/]+/)?release/(\d+)", url)
+    if not match:
+        return None
+
+    try:
+        token = get_config().beets_config["discogs"]["user_token"].as_str()
+    except ConfigError:
+        token = ""
+
+    if not token:
+        log.error("Discogs artwork requires discogs.user_token to be configured")
+        return None
+
+    release_id = match.group(1)
+    headers = {
+        "User-Agent": "Beets-Flask/1.0",
+        "Authorization": f"Discogs token={token}",
+    }
+
+    try:
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.get(
+                f"https://api.discogs.com/releases/{release_id}"
+            ) as response:
+                if response.status != 200:
+                    log.error(
+                        f"Error fetching Discogs art for release {release_id}: "
+                        f"{response.status}"
+                    )
+                    return None
+
+                data = await response.json()
+
+        images = data.get("images", [])
+        return images[0].get("uri150") if images else None
+    except (
+        aiohttp.ClientError,
+        json.JSONDecodeError,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as err:
+        log.error(f"Error parsing Discogs art for release {release_id}: {err}")
+        return None
+
+
+async def _get_beatport_client():
+    """Return or safely initialize the client from the beatport4 plugin.
+
+    See https://github.com/Samik081/beets-beatport4
+
+    Returns the url the the art.
+    """
+
+    get_config()
+    for plugin in find_plugins():
+        if plugin.name != "beatport4":
+            continue
+
+        client = getattr(plugin, "client", None)
+        if client is not None:
+            return client
+
+        tokenfile = getattr(plugin, "_tokenfile", None)
+        setup = getattr(plugin, "setup", None)
+        if not callable(tokenfile) or not callable(setup):
+            return None
+
+        token_path = tokenfile()
+        if not isinstance(token_path, (str, bytes, os.PathLike)):
+            log.error("Beatport token file path is invalid")
+            return None
+
+        if not os.path.isfile(token_path):
+            log.error("Beatport artwork requires an existing beatport4 token file")
+            return None
+
+        try:
+            with open(token_path) as token_file:
+                token_data = json.load(token_file)
+            token_is_valid = float(token_data["expires_at"]) > time.time() + 30
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            token_is_valid = False
+
+        config = getattr(plugin, "config", None)
+        if config is None:
+            has_credentials = False
+        else:
+            try:
+                has_credentials = bool(
+                    config["username"].get() and config["password"].get()
+                )
+            except (AttributeError, ConfigError, KeyError, TypeError):
+                has_credentials = False
+
+        if not token_is_valid and not has_credentials:
+            log.error(
+                "Beatport artwork requires a valid token or configured credentials"
+            )
+            return None
+
+        setup_args = () if len(inspect.signature(setup).parameters) == 0 else (None,)
+        await asyncio.to_thread(setup, *setup_args)
+        return getattr(plugin, "client", None)
+
+    return None
+
+
+def _parse_beatport_art_url(url: str):
+    """Parse and validate a beatport track/album URL."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+
+    host = (parsed.hostname or "").lower()
+    if host not in {"beatport.com", "www.beatport.com"}:
+        return None
+
+    parsed_match = re.compile(
+        r"^/(?P<resource>release|track)/[^/]+/(?P<resource_id>\d+)/?$"
+    ).fullmatch(parsed.path)
+    if not parsed_match:
+        return None
+
+    return parsed_match.group("resource"), parsed_match.group("resource_id")
+
+
+async def get_beatport_art(url: str) -> str | None:
+    """Resolve cover art for Beatport release and track URLs.
+
+    See https://github.com/Samik081/beets-beatport4/blob/main/beetsplug/beatport4/client.py
+
+    Returns the url the the art.
+    """
+
+    parsed_beatport_url = _parse_beatport_art_url(url)
+    if parsed_beatport_url is None:
+        return None
+
+    resource_type, beatport_id = parsed_beatport_url
+
+    try:
+        client = await _get_beatport_client()
+        if client is None:
+            log.error("Beatport artwork requires the beatport4 plugin to be enabled")
+            return None
+        if resource_type == "release":
+            release = await asyncio.to_thread(client.get_release, beatport_id)
+            track = release.tracks[0] if release and release.tracks else None
+        else:
+            track = await asyncio.to_thread(client.get_track, beatport_id)
+
+        if track is None:
+            return None
+        if track.image_dynamic_url:
+            return track.image_dynamic_url.format(w=250, h=250)
+        return track.image_url
+    except Exception as err:
+        log.error(f"Error fetching Beatport art for {url}: {err}")
+        return None
 
 
 async def get_folder_art(url: str):

--- a/backend/tests/integration/test_routes/test_art_preview.py
+++ b/backend/tests/integration/test_routes/test_art_preview.py
@@ -1,0 +1,449 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from confuse import NotFoundError
+from quart import Quart
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "beets_flask"
+    / "server"
+    / "routes"
+    / "art_preview.py"
+)
+SPEC = importlib.util.spec_from_file_location("art_preview_module", MODULE_PATH)
+assert SPEC and SPEC.loader
+ART_PREVIEW_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ART_PREVIEW_MODULE)
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        body: str,
+        status: int = 200,
+        json_data=None,
+        content_type: str = "image/jpeg",
+    ):
+        self._body = body
+        self.status = status
+        self.headers = {"Content-Type": content_type}
+        self.content_type = content_type
+        self.url = "https://example.com/"
+        self._json_data = json_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._body
+
+    async def json(self):
+        return self._json_data if self._json_data is not None else {}
+
+    async def read(self):
+        return self._body.encode("utf-8")
+
+
+class FakeSession:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, *args, **kwargs):
+        url = args[0] if args else kwargs.get("url", "")
+        if "api.discogs.com" in url:
+            return FakeResponse(
+                "",
+                json_data={
+                    "images": [
+                        {
+                            "uri": "https://i.discogs.com/dCbJYqhymK3_icKu4ga-ZLjKKX4HlPUXvxuvAqfXGkE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIyNzUy/NzA0LTE2NDkwMTIz/NDAtNTg1MS5qcGVn.jpeg",
+                            "uri150": "https://i.discogs.com/Xm-jQMTRVgFCHPT6gp6bfaIcle6mySuDtarItXeMYHU/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIyNzUy/NzA0LTE2NDkwMTIz/NDAtNTg1MS5qcGVn.jpeg",
+                        }
+                    ]
+                },
+            )
+
+        if "bandcamp" in url:
+            return FakeResponse(
+                '{"@id": "https://wyattworld.bandcamp.com/album/ketts-cave", "image": ["https://f4.bcbits.com/img/a1802951586_10.jpg"]}'
+            )
+
+        if "spotify" in url:
+            return FakeResponse(
+                "mock-image",
+                json_data={
+                    "thumbnail_url": "https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0220453e7ab1c42d598d8ff24b"
+                },
+            )
+
+        return FakeResponse(
+            "mock-image",
+            json_data={"thumbnail_url": "https://example.com/cover.jpg"},
+        )
+
+
+@pytest.fixture
+def app() -> Quart:
+    app = Quart(__name__)
+    app.register_blueprint(ART_PREVIEW_MODULE.art_blueprint)
+    return app
+
+
+@pytest.fixture
+async def client(app: Quart):
+    return app.test_client()
+
+
+class FakeConfigValue:
+    def as_str(self):
+        return "discogs-token"
+
+
+class FakeBeetsFlaskConfig:
+    def __init__(self, user_token):
+        self.beets_config = {"discogs": {"user_token": user_token}}
+
+
+class FakeBeatportTrack:
+    image_url = "https://geo-media.beatport.com/image_size/1400x1400/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+    image_dynamic_url = (
+        "https://geo-media.beatport.com/image_size/{w}x{h}/"
+        "deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+    )
+
+
+class FakeBeatportRelease:
+    tracks = [FakeBeatportTrack()]
+
+
+class FakeBeatportClient:
+    def get_release(self, beatport_id):
+        assert beatport_id == "4678214"
+        return FakeBeatportRelease()
+
+    def get_track(self, beatport_id):
+        assert beatport_id == "19349876"
+        return FakeBeatportTrack()
+
+
+async def fake_to_thread(function, *args):
+    return function(*args)
+
+
+async def fake_get_beatport_client():
+    return FakeBeatportClient()
+
+
+@pytest.mark.parametrize(
+    ("url", "_expected_location"),
+    [
+        pytest.param(
+            "https://open.spotify.com/album/4zY3KmQkPOCEln8TWT9exA",
+            "https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0220453e7ab1c42d598d8ff24b",
+            id="spotify",
+        ),
+        pytest.param(
+            "https://musicbrainz.org/release/1cf2ae06-bb5e-4256-af6c-e40d406abba5",
+            "https://coverartarchive.org/release/1cf2ae06-bb5e-4256-af6c-e40d406abba5/front-250",
+            id="musicbrainz",
+        ),
+        pytest.param(
+            "https://wyattworld.bandcamp.com/album/ketts-cave",
+            "https://f4.bcbits.com/img/a1802951586_4.jpg",
+            id="bandcamp",
+        ),
+        pytest.param(
+            "https://www.discogs.com/release/22752704-Wyatt-Netherwood",
+            "https://i.discogs.com/Xm-jQMTRVgFCHPT6gp6bfaIcle6mySuDtarItXeMYHU/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIyNzUy/NzA0LTE2NDkwMTIz/NDAtNTg1MS5qcGVn.jpeg",
+            id="discogs",
+        ),
+        pytest.param(
+            "https://www.beatport.com/release/jw-beat/4678214",
+            "https://geo-media.beatport.com/image_size/250x250/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg",
+            id="beatport",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_preview_route_returns_supported_art(
+    client, monkeypatch, url, _expected_location
+):
+    monkeypatch.setattr("aiohttp.ClientSession", FakeSession)
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "get_config",
+        lambda: FakeBeetsFlaskConfig(FakeConfigValue()),
+    )
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "_get_beatport_client",
+        fake_get_beatport_client,
+    )
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    response = await client.get("/art", query_string={"url": url})
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] != ""
+    payload = await response.get_data()
+    assert payload
+
+
+@pytest.mark.asyncio
+async def test_preview_route_returns_error_without_url(client):
+    response = await client.get("/art")
+
+    assert response.status_code == 400
+
+    data = await response.get_json()
+    assert data["message"] == "url query param is required."
+
+
+@pytest.mark.asyncio
+async def test_preview_route_returns_404_for_unsupported_url(client, monkeypatch):
+    monkeypatch.setattr("aiohttp.ClientSession", FakeSession)
+
+    response = await client.get(
+        "/art",
+        query_string={"url": "https://example.com/unsupported"},
+    )
+
+    assert response.status_code == 404
+
+    data = await response.get_json()
+    assert data["error"] == "No art found."
+
+
+@pytest.mark.asyncio
+async def test_get_bandcamp_art_parses_page_metadata(monkeypatch):
+    monkeypatch.setattr("aiohttp.ClientSession", FakeSession)
+
+    art_url = await ART_PREVIEW_MODULE.get_bandcamp_art(
+        "https://wyattworld.bandcamp.com/album/ketts-cave"
+    )
+
+    assert art_url == "https://f4.bcbits.com/img/a1802951586_4.jpg"
+
+
+@pytest.mark.asyncio
+async def test_get_discogs_art_uses_first_release_image(monkeypatch):
+    monkeypatch.setattr("aiohttp.ClientSession", FakeSession)
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "get_config",
+        lambda: FakeBeetsFlaskConfig(FakeConfigValue()),
+    )
+
+    art_url = await ART_PREVIEW_MODULE.get_discogs_art(
+        "https://www.discogs.com/release/22752704-Wyatt-Netherwood"
+    )
+
+    assert (
+        art_url
+        == "https://i.discogs.com/Xm-jQMTRVgFCHPT6gp6bfaIcle6mySuDtarItXeMYHU/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIyNzUy/NzA0LTE2NDkwMTIz/NDAtNTg1MS5qcGVn.jpeg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_discogs_art_returns_none_without_token(monkeypatch):
+    class MissingConfigValue:
+        def as_str(self):
+            raise NotFoundError("discogs.user_token")
+
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "get_config",
+        lambda: FakeBeetsFlaskConfig(MissingConfigValue()),
+    )
+
+    art_url = await ART_PREVIEW_MODULE.get_discogs_art(
+        "https://www.discogs.com/release/22752704-Wyatt-Netherwood"
+    )
+
+    assert art_url is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.beatport.com/release/jw-beat/4678214",
+        "https://www.beatport.com/track/jw-beat/19349876",
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_beatport_art_uses_dynamic_image_url(monkeypatch, url):
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "_get_beatport_client",
+        fake_get_beatport_client,
+    )
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    art_url = await ART_PREVIEW_MODULE.get_beatport_art(url)
+
+    assert (
+        art_url
+        == "https://geo-media.beatport.com/image_size/250x250/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_art_accepts_url_suffixes(monkeypatch):
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "_get_beatport_client",
+        fake_get_beatport_client,
+    )
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    art_url = await ART_PREVIEW_MODULE.get_beatport_art(
+        "https://www.beatport.com/release/jw-beat/4678214/?utm_source=test"
+    )
+
+    assert (
+        art_url
+        == "https://geo-media.beatport.com/image_size/250x250/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_art_uses_static_image_fallback(monkeypatch):
+    class StaticImageTrack:
+        image_url = "https://geo-media.beatport.com/image_size/1400x1400/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+        image_dynamic_url = None
+
+    class StaticImageClient:
+        def get_track(self, beatport_id):
+            assert beatport_id == "19349876"
+            return StaticImageTrack()
+
+    async def get_static_image_client():
+        return StaticImageClient()
+
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "_get_beatport_client",
+        get_static_image_client,
+    )
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    art_url = await ART_PREVIEW_MODULE.get_beatport_art(
+        "https://www.beatport.com/track/jw-beat/19349876"
+    )
+
+    assert (
+        art_url
+        == "https://geo-media.beatport.com/image_size/1400x1400/deb1ee72-5d97-41ea-84b9-7df937a8eadc.jpg"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_art_returns_none_for_empty_release(monkeypatch):
+    class EmptyReleaseClient:
+        def get_release(self, beatport_id):
+            assert beatport_id == "4678214"
+            return type("EmptyRelease", (), {"tracks": []})()
+
+    async def get_empty_release_client():
+        return EmptyReleaseClient()
+
+    monkeypatch.setattr(
+        ART_PREVIEW_MODULE,
+        "_get_beatport_client",
+        get_empty_release_client,
+    )
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    art_url = await ART_PREVIEW_MODULE.get_beatport_art(
+        "https://www.beatport.com/release/jw-beat/4678214"
+    )
+
+    assert art_url is None
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_art_rejects_other_hosts(monkeypatch):
+    art_url = await ART_PREVIEW_MODULE.get_beatport_art(
+        "https://notbeatport.com/release/jw-beat/4678214"
+    )
+
+    assert art_url is None
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_client_initializes_from_existing_token(
+    monkeypatch, tmp_path
+):
+    tokenfile = tmp_path / "beatport_token.json"
+    tokenfile.write_text(
+        '{"access_token": "token", "expires_at": 9999999999, '
+        '"refresh_token": "refresh"}'
+    )
+
+    class FakeBeatportPlugin:
+        name = "beatport4"
+        client: FakeBeatportClient | None = None
+
+        def _tokenfile(self):
+            return str(tokenfile)
+
+        def setup(self, session=None):
+            self.client = FakeBeatportClient()
+
+    plugin = FakeBeatportPlugin()
+    monkeypatch.setattr(ART_PREVIEW_MODULE, "get_config", lambda: {})
+    monkeypatch.setattr(ART_PREVIEW_MODULE, "find_plugins", lambda: [plugin])
+    monkeypatch.setattr(ART_PREVIEW_MODULE.asyncio, "to_thread", fake_to_thread)
+
+    client = await ART_PREVIEW_MODULE._get_beatport_client()
+
+    assert isinstance(client, FakeBeatportClient)
+
+
+@pytest.mark.asyncio
+async def test_get_beatport_client_does_not_prompt_for_expired_token(
+    monkeypatch, tmp_path
+):
+    tokenfile = tmp_path / "beatport_token.json"
+    tokenfile.write_text(
+        '{"access_token": "expired", "expires_at": 1, "refresh_token": "refresh"}'
+    )
+
+    class FakeConfigValue:
+        def get(self):
+            return None
+
+    class FakeBeatportPlugin:
+        name = "beatport4"
+        client = None
+        config = {
+            "username": FakeConfigValue(),
+            "password": FakeConfigValue(),
+        }
+        setup_called = False
+
+        def _tokenfile(self):
+            return str(tokenfile)
+
+        def setup(self):
+            self.setup_called = True
+
+    plugin = FakeBeatportPlugin()
+    monkeypatch.setattr(ART_PREVIEW_MODULE, "get_config", lambda: {})
+    monkeypatch.setattr(ART_PREVIEW_MODULE, "find_plugins", lambda: [plugin])
+
+    client = await ART_PREVIEW_MODULE._get_beatport_client()
+
+    assert client is None
+    assert plugin.setup_called is False

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@icons-pack/react-simple-icons": "^13.13.0",
         "@lucide/lab": "^0.1.2",
         "@mui/material": "^7.3.9",
         "@tanstack/react-query": "^5.101.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@icons-pack/react-simple-icons':
+        specifier: ^13.13.0
+        version: 13.13.0(react@19.2.7)
       '@lucide/lab':
         specifier: ^0.1.2
         version: 0.1.2
@@ -599,6 +602,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@icons-pack/react-simple-icons@13.13.0':
+    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
+    engines: {node: '>=24', pnpm: '>=10'}
+    peerDependencies:
+      react: ^16.13 || ^17 || ^18 || ^19
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -3295,6 +3304,10 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@icons-pack/react-simple-icons@13.13.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/frontend/src/api/library.ts
+++ b/frontend/src/api/library.ts
@@ -11,7 +11,7 @@ import {
     LibraryStats as _LibraryStats,
 } from '@/pythonTypes';
 
-import { queryClient } from './common';
+import { HTTPError, queryClient } from './common';
 
 export type LibraryStats = Omit<
     _LibraryStats,
@@ -469,17 +469,22 @@ export const externalArtQueryOptions = (data_url: string) =>
     queryOptions({
         queryKey: ['externalArt', data_url],
         queryFn: async () => {
-            const blob = await fetch(
+            const response = await fetch(
                 `/art?url=${encodeURIComponent(data_url)}`
-            ).then((r) => r.blob());
-
-            const dataUrl: string = await new Promise((resolve) => {
-                const reader = new FileReader();
-                reader.onload = () => resolve(reader.result as string);
-                reader.readAsDataURL(blob);
-            });
-            return dataUrl;
+            );
+            if (!response.ok) {
+                const text = await response.text();
+                throw new HTTPError(
+                    text || `Failed to load external art: ${response.status}`,
+                    response.status
+                );
+            }
+            const blob = await response.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            return objectUrl;
         },
+        retryOnMount: false,
+        ...ART_QUERY_OPTIONS,
     });
 
 /* ---------------------------- Waveforms / Peaks --------------------------- */

--- a/frontend/src/components/common/icons.tsx
+++ b/frontend/src/components/common/icons.tsx
@@ -1,7 +1,6 @@
 import {
     AudioLinesIcon,
     BadgeAlertIcon,
-    BrainIcon,
     CalendarIcon,
     CassetteTapeIcon,
     CheckIcon,
@@ -36,6 +35,15 @@ import {
     TriangleAlertIcon,
     UserRoundIcon,
 } from 'lucide-react';
+import { type ComponentType, forwardRef } from 'react';
+import type { IconType } from '@icons-pack/react-simple-icons';
+import {
+    SiBandcamp,
+    SiBeatport,
+    SiDiscogs,
+    SiMusicbrainz,
+    SiSpotify,
+} from '@icons-pack/react-simple-icons';
 import { sneaker } from '@lucide/lab';
 import { CircularProgress, Tooltip, useTheme } from '@mui/material';
 
@@ -169,29 +177,39 @@ export function PenaltyTypeIcon({
  */
 export function SourceTypeIcon({
     type,
+    useSourceColors = false,
     ...props
-}: { type: string } & LucideProps) {
-    switch (type.toLowerCase()) {
-        case 'spotify':
-            return <Spotify {...props} />;
-        case 'mb':
-        case 'musicbrainz':
-            return <BrainIcon {...props} />;
-        case 'asis':
-            return <FileMusicIcon {...props} />;
-        default:
-            console.warn(`Unknown source type: ${type}`);
-            return <BadgeAlertIcon {...props} />;
+}: { type: string; useSourceColors?: boolean } & LucideProps) {
+    const sourceType = type.toLowerCase();
+    const config = sourceTypeIconMap[sourceType];
+
+    if (!config) {
+        console.warn(`Unknown source type: ${type}`);
+        return <BadgeAlertIcon color={props.color} {...props} />;
     }
+
+    const Icon = config.icon;
+    const color = useSourceColors ? props.color || config.color : props.color;
+    return <Icon color={color} {...props} />;
 }
 
 export function SourceTypeIconWithTooltip({
     type,
+    useSourceColors = false,
     ...props
-}: { type: string } & LucideProps) {
+}: { type: string; useSourceColors?: boolean } & LucideProps) {
+    const sourceType = type.toLowerCase();
+    const config = sourceTypeIconMap[sourceType];
+    const tooltip = config?.tooltip || type;
+
     return (
-        <Tooltip title={type === 'asis' ? 'Metadata from files' : type}>
-            <SourceTypeIcon type={type} {...props} />
+        <Tooltip title={tooltip}>
+            <SourceTypeIcon
+                type={type}
+                useSourceColors={useSourceColors}
+                color={props.color}
+                {...props}
+            />
         </Tooltip>
     );
 }
@@ -254,46 +272,72 @@ export function FolderStatusIcon({
     }
 }
 
-// Manually edited spotify svg icon (removing the circle)
-function Spotify(props: LucideProps) {
-    return (
-        <svg
-            width={props.size || 24}
-            height={props.size || 24}
-            viewBox={`-1 0 18 18`}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            version="1.1"
-            {...props}
-        >
-            <path
-                stroke="none"
-                d="M 0,0 H 24 V 24 H 0 Z"
-                fill="none"
-                id="path2"
-            />
-            <g transform="translate(-4.3029676,-7.9256576)" id="g1349">
-                <g id="g1196" transform="translate(0.03227154,1.7049163)">
-                    <path
-                        d="m 6.3949311,14.46672 c 3.7367129,-2.201671 8.2207679,-1.454328 11.2101379,0.7877"
-                        id="path6"
-                    />
-                    <path
-                        d="m 8.263287,18.991132 c 2.242028,-1.494685 5.978741,-1.494685 7.473426,0.747343"
-                        id="path8"
-                    />
-                    <path
-                        d="M 4.5265745,10.023022 C 7.5159444,8.5283366 13.494685,7.0336515 19.473425,10.770364"
-                        id="path10"
-                    />
-                </g>
-            </g>
-        </svg>
-    );
+interface SimpleIconBridgeProps extends LucideProps {
+    icon: IconType;
 }
+
+const SimpleIconBridge = forwardRef<SVGSVGElement, SimpleIconBridgeProps>(
+    ({ icon: Icon, color, size, ...props }, ref) => {
+        const iconSize = size ?? 24;
+        return (
+            <Icon
+                ref={ref}
+                // Lucide defaults to "currentColor".
+                // Simple Icons uses 'color' prop for the SVG fill.
+                color={color || 'currentColor'}
+                size={iconSize}
+                width={iconSize}
+                height={iconSize}
+                viewBox="0 0 24 24"
+                {...props}
+            />
+        );
+    }
+);
+
+const MusicBrainz = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+    <SimpleIconBridge ref={ref} icon={SiMusicbrainz} {...props} />
+));
+
+const Spotify = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+    <SimpleIconBridge ref={ref} icon={SiSpotify} {...props} />
+));
+
+const Bandcamp = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+    <SimpleIconBridge ref={ref} icon={SiBandcamp} {...props} />
+));
+
+const Beatport = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+    <SimpleIconBridge ref={ref} icon={SiBeatport} {...props} />
+));
+
+const Discogs = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+    <SimpleIconBridge ref={ref} icon={SiDiscogs} {...props} />
+));
+
+interface SourceTypeIconConfig {
+    icon: ComponentType<LucideProps>;
+    color?: string;
+    tooltip?: string;
+}
+
+const sourceTypeIconMap: Record<string, SourceTypeIconConfig> = {
+    spotify: { icon: Spotify, color: '#1ED760', tooltip: 'Spotify' },
+    bandcamp: { icon: Bandcamp, color: '#408294', tooltip: 'Bandcamp' },
+    discogs: { icon: Discogs, color: undefined, tooltip: 'Discogs' }, // Brand color too dark, so we use default color
+    beatport: { icon: Beatport, color: '#01FF95', tooltip: 'Beatport' },
+    mb: { icon: MusicBrainz, color: '#BA478F', tooltip: 'MusicBrainz' },
+    musicbrainz: {
+        icon: MusicBrainz,
+        color: '#BA478F',
+        tooltip: 'MusicBrainz',
+    },
+    asis: {
+        icon: FileMusicIcon,
+        color: undefined,
+        tooltip: 'Metadata from files',
+    },
+};
 
 // Online-Globe with questionmark
 function ExtraItem(props: LucideProps) {

--- a/frontend/src/components/library/coverArt.tsx
+++ b/frontend/src/components/library/coverArt.tsx
@@ -1,5 +1,5 @@
 import { FileWarningIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@mui/material';
 import Box, { BoxProps } from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
@@ -237,6 +237,16 @@ function CoverArtContent({
     src,
     ...props
 }: { src: string } & Partial<BoxProps>) {
+    useEffect(() => {
+        if (!src.startsWith('blob:')) {
+            return undefined;
+        }
+
+        return () => {
+            URL.revokeObjectURL(src);
+        };
+    }, [src]);
+
     return <Box component="img" src={src} {...props} />;
 }
 


### PR DESCRIPTION
Hello!

First off I wanted to say thank you for all of your hard work on beets-flask - I’ve been using it for a while now and it’s made managing my library so much quicker and more enjoyable!

I’ve prepared a few improvements to the `backend/beets_flask/server/routes/art_preview.py` to fetch artwork from Bandcamp, Discogs, and Beatport (implemented as close to the specific beets plugins as possible) - this should resolve #274.

I've also adjusted the cover-art flow so missing artwork behaves reliably and consistently, while hopefully reducing CORS issues by moving more of the external art resolution to the backend (I no longer see CORS errors in Safari so this should fix #275) and added simple-icons (https://simpleicons.org) for source logos in the frontend.

<img width="4336" height="2794" alt="Screenshot - Add artwork and logo support for additional sources" src="https://github.com/user-attachments/assets/4dc13f4a-8f0e-4d63-845a-e664b11c977a" />


## What’s changed

### Backend
- Added backend-proxied external artwork handling in `/art`.
- Added support for more providers:
  - Bandcamp
  - Discogs
  - Beatport
- Updated resolution behavior so unresolved or missing artwork returns a `404` response from backend.

### Frontend
- Updated `externalArtQueryOptions` to:
  - check `/art` response status before treating it as success
  - throw `HTTPError` on non-OK responses
  - return `URL.createObjectURL(blob)` for successful image payloads

This makes the existing `CoverArtError` fallback path reliably render when artwork can’t be fetched.

### UI
- Added provider logos via `simple-icons` in `SourceTypeIcon`.
- Added optional `useSourceColors?: boolean` so icon colouring is opt-in at some point.

## Why this helps
- Missing artwork now consistently triggers frontend error handling and placeholder UI.
- Artwork fetching is less exposed to browser CORS behavior since it goes through backend proxy flow.
- The source icon set is more accurate and extensible with consistent provider metadata.

## Testing
- Added/updated integration tests in:
  - `backend/tests/integration/test_routes/test_art_preview.py`
- Manual UI verification:
  - missing artwork displays fallback placeholder instead of blank image
  - backend returns `404` for unresolved art URLs
  - error logs are expected and intentional for missing artwork cases

## Links / references
- Fixes #274  
- Related CORS improvement context: #275

## Environment

Used for beets-flask in `requirements.txt`:

```text
beets[discogs]
beetcamp
beets-beatport4
```

Config for beets-flask in `config.yaml`:

```yaml
# ------------------------------------------------------------------------------------ #
#                                   BEETS GUI CONFIG                                   #
# ------------------------------------------------------------------------------------ #
# Example file, this file was automatically copied to /config/beets-flask/config.yaml.
# Feel free to edit this file to customize the gui configuration.
# Especially the `folders` section in the `inbox` section are important to set up your inbox
# folders. You can add as many folders as you like, but don't forget to volume-map them in
# your docker-compose.yml.

gui:
    num_preview_workers: 4 # how many previews to generate in parallel

    library:
        # Use to split artists in the library view if using multiple artists in a field.
        # Set to an empty list to disable this feature.
        artist_separators: [",", ";", "&"]

    terminal:
        start_path: "/music/inbox" # the directory where to start new terminal sessions

    inbox:
        folders:
            # --------------------------------- README -------------------------------- #
            # Before using the inbox feature, you need to create the folders
            # and decide on an inbox type. Have a look at the examples below.

            Inbox1:
                name: "Dummy inbox"
                path: "/music/dummy"
                autotag: no
                # do not automatically trigger tagging and do not automatically import
            Inbox2:
                name: "Auto Inbox"
                path: "/music/inbox_auto"
                autotag: "auto"
                # trigger tag and import if a good match is found based on `auto_threshold`
                auto_threshold: null
                # if set to null, uses the value in beets config (match.strong_rec_thresh)
                # define the distance from a perfect match, i.e. set to 0.1 to import
                # matches with 90% similarity or better.
            Inbox3:
                name: "An Inbox that only generates the previews"
                path: "/music/inbox_preview"
                autotag: "preview"
                # trigger tag but do not import, recommended for most control
```

Config for beets in `config.yaml`:

```yaml
# ------------------------------------------------------------------------------------ #
#                                      BEETS CONFIG                                    #
# ------------------------------------------------------------------------------------ #
# Opinionated example beets configuration. This file was automatically copied to
# /config/beets/config.yaml. Feel free to edit this file to customize the beets
# configuration. For more information on the beets configuration, see
# https://beets.readthedocs.io/en/stable/reference/config.html

plugins: [
        info,
        the,
        fetchart,
        embedart,
        ftintitle,
        lastgenre,
        missing,
        albumtypes,
        scrub,
        zero,
        mbsync,
        duplicates,
        convert,
        fromfilename,
        inline,
        edit,
        # spotify, # needs authentication https://docs.beets.io/en/latest/plugins/spotify.html
        musicbrainz, # needs to be enabled explicitly since beets 2.4.0
        bandcamp,
        discogs,
        beatport4,
    ]

directory: /music/imported
# library: /config/beets/library.db # default location in the container

import:
    move: no
    copy: yes
    write: yes
    log: /music/last_beets_imports.log
    quiet_fallback: skip
    detail: yes
    duplicate_action: ask # ask|skip|merge|keep|remove

ui:
    color: yes

# fix up output file paths
replace:
    '[\\]': ""
    "[_]": "-"
    "[/]": "-"
    '^\.+': ""
    '[\x00-\x1f]': ""
    '[<>:"\?\*\|]': ""
    '\.$': ""
    '\s+$': ""
    '^\s+': ""
    "^-": ""
    "’": ""
    "′": ""
    "″": ""
    "‐": "-"

per_disc_numbering: no
asciify_paths: yes

# adjusting the `threaded` setting of beets should currently have no effect.
# we launch our own workers for previews and only have one
# import worker that runs one import (file moving) at a time.
threaded: no

fetchart:
    minwidth: 500
    enforce_ratio: 10px # yes|no or tolerance around 1:1 ratio
    sources: coverart filesystem itunes amazon spotify albumart fanarttv

embedart:
    auto: yes
    ifempty: yes # whether to avoid embedding album art for files that already have art embedded.
    remove_art_file: yes

ftintitle:
    auto: yes
    format: (feat. {0})

lastgenre: # get genres from last fm
    auto: yes
    count: 4
    prefer_specific: yes # Sort genres by the most to least specific, rather than most to least popular.
    force: yes # By default, beets will always fetch new genres, even if the files already have one
    source: track # album|track
    separator: "; "
    fallback: ""

match:
    # autotagger tolerance [0, 1], default 0.04
    # for example, 0.1 means 90% similarity required.
    # inbox-folder autotag setting 'auto' respects this and imports above the threshold (like the beets cli would)
    strong_rec_thresh: 0.1

    # customize how penalties affect the match score
    distance_weights:
        # source: 2.0
        # artist: 3.0
        # album: 3.0
        # media: 1.0
        # mediums: 1.0
        # year: 1.0
        # country: 0.5
        # label: 0.5
        # catalognum: 0.5
        # albumdisambig: 0.5
        # album_id: 5.0
        # tracks: 2.0
        data_source: 0.0 # do not apply penalty to any data source plugin
        missing_tracks: 0.2 # If your prefer not being so picky about missing tracks. default 0.9
        # unmatched_tracks: 0.6
        # track_title: 3.0
        # track_artist: 2.0
        # track_index: 1.0
        # track_length: 2.0
        # track_id: 5.0

musicbrainz:
    external_ids:
        discogs: yes
        bandcamp: yes
        spotify: yes
        deezer: yes
        beatport: yes
        tidal: yes

discogs:
    user_token: ""

beatport4:
  username: ""
  password: ""
```