### PR TITLE
Add minimal session endpoint for faster frontend loading, plus status/album-detection fixes

### DIFF
--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -23,8 +23,8 @@ jobs:
               with:
                   # list of Docker images to use as base name for tags
                   images: |
-                      pspitzner/beets-flask
-                      ghcr.io/pspitzner/beets-flask
+                      metasauce/beets-flask
+                      ghcr.io/metasauce/beets-flask
                   # generate Docker tags based on the following events/attributes
                   # We use semver and allow pre-releases (e.g. v1.0.0-b1 or v1.0.0-rc3) to be tagged as 'latest' for testing purposes
                   # The 'stable' tag is only applied to non-prerelease versions (e.g. v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/metasauce/beets-flask/pull/224)
 - You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/metasauce/beets-flask/issues/260)
 - Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/metasauce/beets-flask/pull/277)
+- Faster loading of the inbox: chip info (best match, duplicates, data source) is now fetched via a new lightweight `/session/minimal` endpoint, batched in a single request instead of loading full session states.
 
 ### Fixed
 
@@ -35,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
 - Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/metasauce/beets-flask/pull/305)
 - Fixed an issue with timestamps shown in the library view [#289](https://github.com/metasauce/beets-flask/issues/289)
+- A failed import no longer leaves a stale error behind after a successful reimport of the same folder.
+- Folders without any import session no longer show a misleading "Unknown"/"Not started" badge.
+- Folders containing only non-music files (e.g. stray uploads like `foo.txt`) are no longer detected as albums and auto-tagged by the watchdog.
+- Session and inbox data is now cached in the frontend and only refetched when it actually changes, instead of on every view.
 
 ### Other (dev)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes ⚠️
 
-- **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/pSpitzner/beets-flask/issues/212)
+- **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/metasauce/beets-flask/issues/212)
 - **Upgraded `beets` from `v2.5.1` to `v2.12.0`**
-    - This contains many changes and improvements, including some plugins.
-    - See the changelog at [beets.readthedocs.io](https://beets.readthedocs.io/en/stable/changelog.html)
+  - This contains many changes and improvements, including some plugins.
+  - See the changelog at [beets.readthedocs.io](https://beets.readthedocs.io/en/stable/changelog.html)
 - Changed config options (beets-flask):
-    - `gui.inbox.folders.your_inbox.autotag` no longer accepts `false`, use `"off"` instead. (This was needed for consistency for the new config validation)
+  - `gui.inbox.folders.your_inbox.autotag` no longer accepts `false`, use `"off"` instead. (This was needed for consistency for the new config validation)
 - Changed config options (beets):
-    - `fetchart.sources` were changed, if you get errors from our previous defaults: change to `"*"`
-
+  - `fetchart.sources` were changed, if you get errors from our previous defaults: change to `"*"`
 
 ### Added
 
-- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
+- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/metasauce/beets-flask/pull/224).
 - Upload Files via the WebUI. You can now drag-and-drop single files into an inbox. To upload whole albums, zip them on your host first (uploading of folders directly is not implemented, as it would require a secure context).
-- New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
-- You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)
-- Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/pSpitzner/beets-flask/pull/277)
+- New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/metasauce/beets-flask/pull/224)
+- You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/metasauce/beets-flask/issues/260)
+- Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/metasauce/beets-flask/pull/277)
 
 ### Fixed
 
-- Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/pSpitzner/beets-flask/issues/264)
-- Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/pSpitzner/beets-flask/issues/258)
-- Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/pSpitzner/beets-flask/issues/282)
+- Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/metasauce/beets-flask/issues/264)
+- Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/metasauce/beets-flask/issues/258)
+- Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/metasauce/beets-flask/issues/282)
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
-- Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
-- Fixed an issue with timestamps shown in the library view [#289](https://github.com/pSpitzner/beets-flask/issues/289)
+- Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/metasauce/beets-flask/pull/305)
+- Fixed an issue with timestamps shown in the library view [#289](https://github.com/metasauce/beets-flask/issues/289)
 
 ### Other (dev)
 
@@ -55,22 +54,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duration component could display nothing in some edge cases.
 - Action buttons now have a slight box shadow and are a bit more visible.
 - We now support playing container types [m4a, mp4, mov, alac, aac, mp3] that require seeking. This should fix issues with some mp4/m4a files not playing.
-- If no candidates are found during an import, we now show a message instead of an empty screen. [#190](https://github.com/pSpitzner/beets-flask/issues/190)
-- Archive files can now be deleted [#217](https://github.com/pSpitzner/beets-flask/issues/217)
-- Import Bootleg Button now works as expected [#218](https://github.com/pSpitzner/beets-flask/issues/218)
-- Startup script was not executed correctly if placed in `/config/beets-flask/startup.sh` [#227](https://github.com/pSpitzner/beets-flask/pull/227)
-- Another state-related bug around Searching for Candidates [#225](https://github.com/pSpitzner/beets-flask/issues/225). We now no longer require a certaint type of state before allowing to add candidates.
+- If no candidates are found during an import, we now show a message instead of an empty screen. [#190](https://github.com/metasauce/beets-flask/issues/190)
+- Archive files can now be deleted [#217](https://github.com/metasauce/beets-flask/issues/217)
+- Import Bootleg Button now works as expected [#218](https://github.com/metasauce/beets-flask/issues/218)
+- Startup script was not executed correctly if placed in `/config/beets-flask/startup.sh` [#227](https://github.com/metasauce/beets-flask/pull/227)
+- Another state-related bug around Searching for Candidates [#225](https://github.com/metasauce/beets-flask/issues/225). We now no longer require a certaint type of state before allowing to add candidates.
 - Asis candidates have been restyled to be more consistent with other candidate types. They now also include a cover art preview if available.
-- Fixed a typo in our opiniated beets config [#235](https://github.com/pSpitzner/beets-flask/issues/235)
+- Fixed a typo in our opiniated beets config [#235](https://github.com/metasauce/beets-flask/issues/235)
 - Fixed a styling issue in the artists list view which caused an overflow
 - Fixed a styling issue where an extra cancel-button (cross) was shown on webkit browsers
 
 ### Added
 
-- Added ability to define more groups to take care of ACLs, so that our non-root user can delete files on host systems, if desired. New environment variable `EXTRA_GROUPS` [#234](https://github.com/pSpitzner/beets-flask/issues/234)
-- The inbox info button now has a description of all actions [#145](https://github.com/pSpitzner/beets-flask/issues/145)
-- Subpage for version information and configs. You can access it via the version number in the navbar. [#205](https://github.com/pSpitzner/beets-flask/issues/205)
-- New config option `gui.inbox.debounce_before_autotag` to configure how many seconds to wait after the last filesystem event before starting autotagging. Same debounce applies to all inboxes. [#222](https://github.com/pSpitzner/beets-flask/issues/222)
+- Added ability to define more groups to take care of ACLs, so that our non-root user can delete files on host systems, if desired. New environment variable `EXTRA_GROUPS` [#234](https://github.com/metasauce/beets-flask/issues/234)
+- The inbox info button now has a description of all actions [#145](https://github.com/metasauce/beets-flask/issues/145)
+- Subpage for version information and configs. You can access it via the version number in the navbar. [#205](https://github.com/metasauce/beets-flask/issues/205)
+- New config option `gui.inbox.debounce_before_autotag` to configure how many seconds to wait after the last filesystem event before starting autotagging. Same debounce applies to all inboxes. [#222](https://github.com/metasauce/beets-flask/issues/222)
 - The library view on mobile now has a button to collapse the overview (above the tabs). This allows for more space when browsing the library on small screens.
 
 ### Other (dev)
@@ -100,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolved an issue in Vite development server where pythonTypes.ts would fail to load on first start due to inconsistent indentation (tabs vs spaces). This only affected the dev environment.
 - Development Docker container now runs as the `beetle` user instead of root, improving parity with the production environment.
-- Trailing slashes in configured inbox paths no longer cause crashes. [#182](https://github.com/pSpitzner/beets-flask/issues/182)
+- Trailing slashes in configured inbox paths no longer cause crashes. [#182](https://github.com/metasauce/beets-flask/issues/182)
 - The container now sets the `EDITOR` environment variable to `vi` so that `beet edit` and `beet config -e` work out of the box.
 
 ### Dependencies
@@ -112,14 +111,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Updated refresh_config to scan all modules for config references and overwrite them as needed to ensure consistency [#188](https://github.com/pSpitzner/beets-flask/issues/188)
+- Updated refresh_config to scan all modules for config references and overwrite them as needed to ensure consistency [#188](https://github.com/metasauce/beets-flask/issues/188)
 
 ## [1.1.1] - 25-08-15
 
 ### Fixed
 
-- Session cache wasn't invalidated on all folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/pSpitzner/beets-flask/issues/163)
-- We now use the beets `ignore` config option to ignore files and folders in the inbox view. This allows you to ignore files like `*.tmp`, `*.log`, etc. We also allow users to define the `gui.inbox.ignore` option to customize the ignored file patterns. [#176](https://github.com/pSpitzner/beets-flask/issues/176)
+- Session cache wasn't invalidated on all folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/metasauce/beets-flask/issues/163)
+- We now use the beets `ignore` config option to ignore files and folders in the inbox view. This allows you to ignore files like `*.tmp`, `*.log`, etc. We also allow users to define the `gui.inbox.ignore` option to customize the ignored file patterns. [#176](https://github.com/metasauce/beets-flask/issues/176)
 - Scrollbar for beets instructions wasn't visible on small screens.
 
 ### Other (dev)
@@ -144,14 +143,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed search results not showing [#161](https://github.com/pSpitzner/beets-flask/issues/161))
-- Fixed search box not clickable on small screens [#162](https://github.com/pSpitzner/beets-flask/issues/162)
+- Fixed search results not showing [#161](https://github.com/metasauce/beets-flask/issues/161))
+- Fixed search box not clickable on small screens [#162](https://github.com/metasauce/beets-flask/issues/162)
 
 ## [1.0.2] - 25-07-21
 
 ### Fixed
 
-- Artists separators were not regex escaped correctly, leading to issues with artists containing special characters. Additionally an empty list of separators was not handled correctly. [#159](https://github.com/pSpitzner/beets-flask/issues/159)
+- Artists separators were not regex escaped correctly, leading to issues with artists containing special characters. Additionally an empty list of separators was not handled correctly. [#159](https://github.com/metasauce/beets-flask/issues/159)
 
 ## [1.0.1] - 25-07-17
 
@@ -168,10 +167,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For bootlegs, display of track changes after import no longer broken
 - Navigating from inbox into folder details no longer toggles selection.
 - Padding issue where navbar could block content on mobile.
-- Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/pSpitzner/beets-flask/issues/138)
-- In albums and items view the clicking on artists does not return any results if the contained a separator character (e.g. `&`) [#132](https://github.com/pSpitzner/beets-flask/issues/138)
-- Cleanup old actions.tsx file, which included old unused code [#134](https://github.com/pSpitzner/beets-flask/issues/134)
-- The `cli_exit` event is now triggered after the import task is finished. This adds compatibility with some plugins which expected this event to be triggered after the import task is done. [#154](https://github.com/pSpitzner/beets-flask/issues/154).
+- Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/metasauce/beets-flask/issues/138)
+- In albums and items view the clicking on artists does not return any results if the contained a separator character (e.g. `&`) [#132](https://github.com/metasauce/beets-flask/issues/138)
+- Cleanup old actions.tsx file, which included old unused code [#134](https://github.com/metasauce/beets-flask/issues/134)
+- The `cli_exit` event is now triggered after the import task is finished. This adds compatibility with some plugins which expected this event to be triggered after the import task is done. [#154](https://github.com/metasauce/beets-flask/issues/154).
 
 ### Changed
 
@@ -233,7 +232,7 @@ Small version bump with fixes before jumping to 1.0.0.
 ### Added
 
 - Logo and favicon
-- Image now on docker hub: `pspitzner/beets-flask:stable`
+- Image now on docker hub: `metasauce/beets-flask:stable`
 - Auto-import: automatically import folders that are added to the inbox if the match is good enough.
   After a preview, import will start if the match quality is above the configured.
   Enable via the config.yaml, set the `autotag` field of a configred inbox folders to `"auto"`.
@@ -287,17 +286,17 @@ Small version bump with fixes before jumping to 1.0.0.
 
 - initial commit
 
-[Unreleased]: https://github.com/pSpitzner/beets-flask/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/pSpitzner/beets-flask/compare/v1.1.3...v1.2.0
-[1.1.3]: https://github.com/pSpitzner/beets-flask/compare/v1.1.2...v1.1.3
-[1.1.2]: https://github.com/pSpitzner/beets-flask/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/pSpitzner/beets-flask/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/pSpitzner/beets-flask/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/pSpitzner/beets-flask/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/pSpitzner/beets-flask/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/pSpitzner/beets-flask/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/pSpitzner/beets-flask/compare/v0.1.0...v1.0.0
-[0.1.0]: https://github.com/pSpitzner/beets-flask/compare/v0.0.4...v0.1.0
-[0.0.4]: https://github.com/pSpitzner/beets-flask/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/pSpitzner/beets-flask/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/pSpitzner/beets-flask/compare/v0.0.1...v0.0.2
+[Unreleased]: https://github.com/metasauce/beets-flask/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/metasauce/beets-flask/compare/v1.1.3...v1.2.0
+[1.1.3]: https://github.com/metasauce/beets-flask/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/metasauce/beets-flask/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/metasauce/beets-flask/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/metasauce/beets-flask/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/metasauce/beets-flask/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/metasauce/beets-flask/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/metasauce/beets-flask/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/metasauce/beets-flask/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/metasauce/beets-flask/compare/v0.0.4...v0.1.0
+[0.0.4]: https://github.com/metasauce/beets-flask/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/metasauce/beets-flask/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/metasauce/beets-flask/compare/v0.0.1...v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes ⚠️
 
+- **Repository moved**: The repository has moved from `pSpitzner/beets-flask` to `metasauce/beets-flask`. Please update your remotes and bookmarks accordingly.
 - **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/metasauce/beets-flask/issues/212)
 - **Upgraded `beets` from `v2.5.1` to `v2.12.0`**
   - This contains many changes and improvements, including some plugins.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -d -p 5001:5001 \
 ```yaml
 services:
     beets-flask:
-        image: pspitzner/beets-flask:stable
+        image: metasauce/beets-flask:stable
         restart: unless-stopped
         ports:
             - "5001:5001"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     <h1 align="center">Beets-flask</h1>
 </p>
 
-[![version number](https://img.shields.io/github/package-json/v/pspitzner/beets-flask/main?filename=frontend%2Fpackage.json&label=version&color=blue)](https://github.com/pSpitzner/beets-flask/blob/main/CHANGELOG.md)
-[![Docker Pulls](https://img.shields.io/docker/pulls/pspitzner/beets-flask)](https://hub.docker.com/r/pspitzner/beets-flask/tags)
+[![version number](https://img.shields.io/github/package-json/v/metasauce/beets-flask/main?filename=frontend%2Fpackage.json&label=version&color=blue)](https://github.com/metasauce/beets-flask/blob/main/CHANGELOG.md)
+[![Docker Pulls](https://img.shields.io/docker/pulls/metasauce/beets-flask)](https://hub.docker.com/r/metasauce/beets-flask/tags)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?label=license)](https://opensource.org/licenses/MIT)
-[![docker-hub build status](https://img.shields.io/github/actions/workflow/status/pSpitzner/beets-flask/docker_hub.yml?label=docker%20build)](https://github.com/pSpitzner/beets-flask/pkgs/container/beets-flask)
+[![docker-hub build status](https://img.shields.io/github/actions/workflow/status/metasauce/beets-flask/docker_hub.yml?label=docker%20build)](https://github.com/metasauce/beets-flask/pkgs/container/beets-flask)
 [![Documentation Status](https://readthedocs.org/projects/beets-flask/badge/?version=latest)](https://beets-flask.readthedocs.io/en/latest/?badge=latest)
 
 <p align="center">
@@ -19,14 +19,14 @@
 
 <!-- start features -->
 
--   Autogenerate previews before importing
--   Auto-Import good matches
--   Import via GUI
--   Undo imports
--   Web-Terminal
--   Monitor multiple inboxes
--   Drag-and-drop files to upload into inboxes
--   Library view and search
+- Autogenerate previews before importing
+- Auto-Import good matches
+- Import via GUI
+- Undo imports
+- Web-Terminal
+- Monitor multiple inboxes
+- Drag-and-drop files to upload into inboxes
+- Library view and search
 
 <!-- end features -->
 
@@ -48,7 +48,6 @@ This is the main idea with beets-flask: For all folders in your inbox, we genera
 
 We provide a docker image with the full beeets-flask setup. You can run it with docker-compose or docker. We recommend using the `stable` tag, alternatively you may use `latest` for the most recent build.
 
-
 ### Setup container
 
 **Using docker**
@@ -64,7 +63,7 @@ docker run -d -p 5001:5001 \
     -v /music_path/inbox/:/music_path/inbox/ \
     -v /music_path/clean/:/music_path/clean/ \
     --name beets-flask \
-    pspitzner/beets-flask:stable
+    metasauce/beets-flask:stable
 ```
 
 <!-- end setup container -->

--- a/backend/beets_flask/database/models/states.py
+++ b/backend/beets_flask/database/models/states.py
@@ -14,24 +14,28 @@ Why not just have State and StateInDb in the same class?
 from __future__ import annotations
 
 import pickle
+from collections.abc import Sequence
 from pathlib import Path
 
 from beets.importer import Action
 from sqlalchemy import (
     ForeignKey,
     UniqueConstraint,
+    case,
     select,
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     Mapped,
     Session,
     mapped_column,
     relationship,
 )
+from sqlalchemy.sql.elements import ColumnElement
 
 from beets_flask.database.mapper.base import Context
 from beets_flask.database.models.base import Base
-from beets_flask.database.models.match import Match
+from beets_flask.database.models.match import Distance, Match
 from beets_flask.disk import Archive, Folder
 from beets_flask.importer.progress import Progress
 from beets_flask.importer.states import SessionState
@@ -268,6 +272,60 @@ class SessionStateInDb(Base):
 
             return item
 
+    @classmethod
+    def get_ids_by_hash_and_path(
+        cls,
+        hash_path_pairs: Sequence[tuple[str | None, Path | str | None]],
+        db_session: Session | None = None,
+    ) -> list[str | None]:
+        """Resolve many (hash, path) pairs to session ids in two queries.
+
+        Same lookup semantics as `get_by_hash_and_path`: by hash first
+        (latest revision), then by path (most recently updated session).
+        Returns a sequence of session ids in the same order as the input
+        pairs; unresolved pairs map to None.
+        """
+        from beets_flask.database import db_session_factory
+
+        with db_session_factory(db_session) as db_session:
+            by_hash: dict[str, str] = {}
+            hashes = [h for h, _ in hash_path_pairs if h]
+            if hashes:
+                query = (
+                    select(cls.folder_hash, cls.id)
+                    .where(cls.folder_hash.in_(hashes))
+                    # highest revision first
+                    .order_by(cls.folder_revision.desc())
+                )
+                for folder_hash, session_id in db_session.execute(query).all():
+                    by_hash.setdefault(folder_hash, session_id)
+
+            pending = [
+                (i, str(p))
+                for i, (h, p) in enumerate(hash_path_pairs)
+                if (not h or h not in by_hash) and p
+            ]
+            by_path: dict[str, str] = {}
+            if pending:
+                query = (
+                    select(FolderInDb.full_path, cls.id)
+                    .join(cls.folder)
+                    .where(FolderInDb.full_path.in_([p for _, p in pending]))
+                    # most recently updated first
+                    .order_by(cls.updated_at.desc(), cls.folder_revision.desc())
+                )
+                for full_path, session_id in db_session.execute(query).all():
+                    by_path.setdefault(full_path, session_id)
+
+            result: list[str | None] = [None] * len(hash_path_pairs)
+            for i, (h, p) in enumerate(hash_path_pairs):
+                item = by_hash.get(h) if h else None
+                if item is None and p:
+                    item = by_path.get(str(p))
+                result[i] = item
+
+            return result
+
     @property
     def exception(self) -> SerializedException | None:
         """Returns the exception of the session if it failed."""
@@ -414,6 +472,28 @@ class CandidateStateInDb(Base):
         self.match = match
         self.task = task
         self.duplicate_ids = ";".join(map(str, duplicate_ids))
+
+    @hybrid_property
+    def normalized_distance(self) -> float:
+        """Normalized beets distance of this candidate (0-1, lower is better).
+
+        A max distance of zero (no penalties) counts as a perfect match.
+        """
+        distance = self.match.distance
+        if distance.max_distance == 0:
+            return 0.0
+        return distance.raw_distance / distance.max_distance
+
+    @normalized_distance.inplace.expression
+    def _normalized_distance_expression(cls) -> ColumnElement[float]:
+        """SQL counterpart of `normalized_distance`.
+
+        Requires joins to `Match` and `Distance` in the query.
+        """
+        return case(
+            (Distance.max_distance == 0, 0.0),
+            else_=Distance.raw_distance / Distance.max_distance,
+        )
 
 
 __all__ = ["SessionStateInDb", "TaskStateInDb", "CandidateStateInDb"]

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -234,7 +234,7 @@ def is_archive_file(path: Path | str) -> bool:
     """Check if a file is an archive file based on its extension.
 
     It seems like there is a memory issue with `tarfile.is_tarfile`
-    (see https://github.com/pSpitzner/beets-flask/issues/258). We try
+    (see https://github.com/metasauce/beets-flask/issues/258). We try
     to avoid this by only checking the file extension here, and not trying to open the file.
     """
     allowed_extensions = allowed_archive_extensions()

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -358,7 +358,11 @@ def is_album_folder(path: Path | str):
     if is_archive_file(path):
         return True
     for paths, items in albums_in_dir(bytestring_path(path)):
-        if all(is_archive_file(i.decode("utf-8")) for i in items):
+        items_str = [i.decode("utf-8") for i in items]
+        if all(is_archive_file(i) for i in items_str):
+            continue
+        # Same music-file requirement as in `all_album_folders`.
+        if not any(audio_regex.match(os.path.basename(i)) for i in items_str):
             continue
         if str(path).encode("utf-8") in paths:
             return True
@@ -387,6 +391,8 @@ def all_album_folders(root_dir: Path | str, subdirs: bool = False) -> list[Path]
 
     folders: list[bytes] = []
     for paths, items in albums_in_dir(bytestring_path(root_dir.absolute())):
+        items_str = [i.decode("utf-8") for i in items]
+
         # Our choice on handling archives:
         # - archives are always simple albums. no multi-disc logic supported,
         #   all discs need to be _inside_ the archive.
@@ -394,9 +400,14 @@ def all_album_folders(root_dir: Path | str, subdirs: bool = False) -> list[Path]
         #   album folder
         # - if a folder contains a mix of archives and music files, it will be
         #   considered an album folder (as we think archives might be metadata or additional files e.g. cover art)
-
-        if all(is_archive_file(i.decode("utf-8")) for i in items):
+        if all(is_archive_file(i) for i in items_str):
             folders.extend(items)
+            continue
+
+        # beets `albums_in_dir` treats any directory with *any* files as an
+        # album. Require at least one music file; stray uploads or cover art
+        # without music do not make a folder an album.
+        if not any(audio_regex.match(os.path.basename(i)) for i in items_str):
             continue
 
         if subdirs:

--- a/backend/beets_flask/importer/session.py
+++ b/backend/beets_flask/importer/session.py
@@ -382,14 +382,14 @@ class BaseSession(BeetsImportSession, ABC):
         log.info(f"Running {self.__class__.__name__} on state<{self.state.id=}>.")
         log.debug(f"Running {len(self.pipeline.stages)} stages.")
 
-        # reset exception state
-        # TODO: To clear or not to clear,
-        # exception hierarchy and own table for exceptions/warnings
-        # self.state.exc = None
+        # TODO: exception hierarchy and own table for exceptions/warnings
         plugins.send("import_begin", session=self)
         try:
             assert self.pipeline is not None
             await self.pipeline.run_async()
+
+            # Clear error on successful run (e.g. from a previous run on the same session)
+            self.state.exc = None
         except ImportAbortError:
             log.debug(f"Interactive import session aborted by user")
         except ApiException as e:

--- a/backend/beets_flask/invoker/enqueue.py
+++ b/backend/beets_flask/invoker/enqueue.py
@@ -452,18 +452,24 @@ async def run_preview(
         try:
             await p_session.run_async()
         finally:
-            # Get max revision for this folder hash
-            stmt = select(func.max(SessionStateInDb.folder_revision)).where(
-                SessionStateInDb.folder_hash == hash,
-            )
-            max_rev = db_session.execute(stmt).scalar_one_or_none()
-            new_rev = 0 if max_rev is None else max_rev + 1
+            # A folder without any media files does not produce tasks and thus
+            # no meaningful session. Skip persisting it, otherwise the folder
+            # shows up with a misleading "not started" status.
+            if len(p_session.state.task_states) == 0:
+                log.debug(f"No tasks read from {path}, not persisting preview session.")
+            else:
+                # Get max revision for this folder hash
+                stmt = select(func.max(SessionStateInDb.folder_revision)).where(
+                    SessionStateInDb.folder_hash == hash,
+                )
+                max_rev = db_session.execute(stmt).scalar_one_or_none()
+                new_rev = 0 if max_rev is None else max_rev + 1
 
-            s_state_indb = SessionStateInDb.from_live_state(p_session.state)
-            s_state_indb.folder_revision = new_rev
+                s_state_indb = SessionStateInDb.from_live_state(p_session.state)
+                s_state_indb.folder_revision = new_rev
 
-            db_session.merge(s_state_indb)
-            db_session.commit()
+                db_session.merge(s_state_indb)
+                db_session.commit()
 
     log.info(f"Preview done. {hash=} {path=}")
     return

--- a/backend/beets_flask/server/routes/db_models/session.py
+++ b/backend/beets_flask/server/routes/db_models/session.py
@@ -1,16 +1,27 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import TypedDict
 
-from quart import jsonify, request
+from quart import Response, jsonify, request
 from rq.job import Job
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.orm import aliased
 
 from beets_flask import invoker
 from beets_flask.database import db_session_factory
 from beets_flask.database.mapper.base import Context
 from beets_flask.database.mapper.states import SessionStateMapper
+from beets_flask.database.models.match import (
+    AlbumInfo,
+    AlbumMatch,
+    Distance,
+    Match,
+    TrackInfo,
+    TrackMatch,
+)
 from beets_flask.database.models.states import (
+    CandidateStateInDb,
     FolderInDb,
     SessionStateInDb,
     TaskStateInDb,
@@ -31,7 +42,37 @@ from beets_flask.server.websocket.status import FolderStatusUpdate, JobStatusUpd
 
 from .base import ModelAPIBlueprint
 
-__all__ = ["SessionAPIBlueprint"]
+__all__ = ["SessionAPIBlueprint", "MinimalChipInfo"]
+
+
+class MinimalBestCandidateInfo(TypedDict):
+    """Minimal best match info.
+
+    Data conciouse representation of the best match for a session, used for chips and minimal session
+    info. This is a subset of the full match state, containing only the most
+    relevant information for quick access.
+    """
+
+    data_source: str
+    distance: float
+    duplicates: list[int]
+
+
+class MinimalSession(TypedDict):
+    """Minimal session info.
+
+    Data conciouse representation of the session, used for chips and minimal session
+    info. This is a subset of the full session state, containing only the most
+    relevant information for quick access.
+    """
+
+    session_id: str
+    # The folder hash for when the session was run. May differ from the
+    # current (live) folder hash if the content changed since then.
+    folder_hash: str
+
+    # Minimal info for the best candidate
+    best_candidate: MinimalBestCandidateInfo
 
 
 class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
@@ -41,26 +82,37 @@ class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
     def _register_routes(self) -> None:
         """Register the routes for the blueprint."""
         super()._register_routes()
-        self.blueprint.route("/by_folder", methods=["POST"])(self.get_by_folder)
+        self.blueprint.route("/full", methods=["GET"])(self.get_full)
         self.blueprint.route("/status", methods=["GET"])(self.get_status)
+        self.blueprint.route("/minimal", methods=["GET"])(self.get_minimal)
+
         self.blueprint.route("/enqueue", methods=["POST"])(self.enqueue)
         self.blueprint.route("/add_candidates", methods=["POST"])(self.add_candidates)
 
-    async def get_by_folder(self):
-        """Returns the most recent session state for a given folder hash or path."""
+    async def get_full(self):
+        """Returns the most recent session state for a given folder hash or path.
 
-        params = await request.get_json()
-        folder_hashes, folder_paths = pop_folder_params(params, allow_mismatch=True)
+        Parameters
+        ----------
+        folder_hash : str
+            Live content hash of the folder to check.
+        folder_path : str (optional)
+            Path of the folder to check. Used as a fallback to find sessions for folders
+            whose content changed.
+        """
 
-        if len(folder_hashes) != 1 and len(folder_paths) != 1:
+        folder_hash = request.args.get("folder_hash")
+        folder_path = request.args.get("folder_path")
+
+        if not folder_hash and not folder_path:
             raise InvalidUsageException(
                 "Provide one folder hash OR one folder path", status_code=400
             )
 
         with db_session_factory() as db_session:
             item = self.model.get_by_hash_and_path(
-                hash=folder_hashes[0],
-                path=folder_paths[0],
+                hash=folder_hash,
+                path=folder_path,
                 db_session=db_session,
             )
 
@@ -70,13 +122,139 @@ class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
                 # frontend console with errors.
                 # we manually handle this in sessionQueryOptions.
                 raise NotFoundException(
-                    f"Item with {folder_hashes=} {folder_paths=} not found",
+                    f"Item with {folder_hash=} {folder_path=} not found",
                     status_code=200,
                 )
 
             mapper = SessionStateMapper(want_to_serialize=True)
             live_state = mapper.from_db(item, Context())
             return jsonify(live_state.serialize())
+
+    async def get_minimal(self) -> Response:
+        """Get minimal chip info for given folder(s).
+
+        Parameters
+        ----------
+        folder_hash : list[str]
+            Live content hashes of the folders to check, as repeated query
+            params.
+        folder_path : list[str]
+            Live paths of the folders to check, as repeated query params. Used as a
+            fallback to find sessions for folders whose content changed.
+
+        Returns
+        -------
+        dict[str, MinimalChipInfo]
+            Keyed by live folder hash: `session_id` and `folder_hash` of the
+            resolved session, `duplicate` (beets id of the duplicate for the
+            best match, or null), `distance` (normalized match distance of
+            the best match) and `data_source`. Folders without a session are
+            omitted.
+        """
+        folder_hashes = request.args.getlist("folder_hash")
+        folder_paths = request.args.getlist("folder_path")
+
+        if len(folder_hashes) == 0:
+            raise InvalidUsageException(
+                "Provide at least one folder hash", status_code=400
+            )
+
+        if len(folder_hashes) != len(folder_paths):
+            raise InvalidUsageException(
+                "Provide the same number of folder hashes and paths", status_code=400
+            )
+
+        with db_session_factory() as db_session:
+            data: dict[str, MinimalSession] = {}
+            session_ids = self.model.get_ids_by_hash_and_path(
+                list(zip(folder_hashes, folder_paths)),
+                db_session,
+            )
+            resolved_ids = [sid for sid in session_ids if sid is not None]
+            if resolved_ids:
+                # Rank candidates within each session by their normalized
+                # distance (CandidateStateInDb.normalized_distance) so only the
+                # best candidate per session is loaded. Select just the scalar
+                # fields we need - no ORM entities, so no tasks or matches are
+                # loaded.
+                #
+                # AlbumMatch/TrackMatch are joined-table subclasses of Match:
+                # aliased(..., flat=True) prevents SQLAlchemy from
+                # auto-generating overlapping-table aliases.
+                album_match = aliased(AlbumMatch, flat=True)
+                track_match = aliased(TrackMatch, flat=True)
+                best_candidate = (
+                    select(
+                        SessionStateInDb.folder_hash,
+                        SessionStateInDb.id.label("session_id"),
+                        CandidateStateInDb.duplicate_ids,
+                        CandidateStateInDb.normalized_distance.label("distance"),
+                        func.coalesce(
+                            AlbumInfo.data["data_source"].as_string(),
+                            TrackInfo.data["data_source"].as_string(),
+                        ).label("data_source"),
+                        func.row_number()
+                        .over(
+                            partition_by=SessionStateInDb.id,
+                            order_by=CandidateStateInDb.normalized_distance,
+                        )
+                        .label("rn"),
+                    )
+                    .join(
+                        TaskStateInDb,
+                        CandidateStateInDb.task_id == TaskStateInDb.id,
+                    )
+                    .join(
+                        SessionStateInDb,
+                        TaskStateInDb.session_id == SessionStateInDb.id,
+                    )
+                    .where(SessionStateInDb.id.in_(resolved_ids))
+                    .join(Match, CandidateStateInDb.match_id == Match.id)
+                    .join(Distance, Match.distance_id == Distance.id)
+                    .outerjoin(album_match, album_match.id == Match.id)
+                    .outerjoin(AlbumInfo, AlbumInfo.id == album_match.info_id)
+                    .outerjoin(track_match, track_match.id == Match.id)
+                    .outerjoin(TrackInfo, TrackInfo.id == track_match.info_id)
+                    .subquery()
+                )
+
+                stmt = select(
+                    best_candidate.c.session_id,
+                    best_candidate.c.folder_hash,
+                    best_candidate.c.duplicate_ids,
+                    best_candidate.c.distance,
+                    best_candidate.c.data_source,
+                ).where(best_candidate.c.rn == 1)
+                rows = db_session.execute(stmt).all()
+
+                rows_by_session = {
+                    session_id: (folder_hash, duplicate_ids, distance, data_source)
+                    for session_id, folder_hash, duplicate_ids, distance, data_source in rows
+                }
+
+                for session_id, folder_hash_org in zip(session_ids, folder_hashes):
+                    if session_id is None:
+                        continue
+                    row = rows_by_session.get(session_id)
+                    if row is None:
+                        continue
+                    folder_hash_sess, duplicate_ids, distance, data_source = row
+                    dup_ids = (
+                        [int(dup_id) for dup_id in duplicate_ids.split(";")]
+                        if duplicate_ids
+                        else []
+                    )
+                    data[folder_hash_org] = MinimalSession(
+                        session_id=session_id,
+                        folder_hash=folder_hash_sess,
+                        best_candidate=MinimalBestCandidateInfo(
+                            duplicates=dup_ids,
+                            distance=distance,
+                            data_source=data_source,
+                        ),
+                    )
+
+            return jsonify(data)
 
     async def enqueue(self):
         """Start a new session for a given folder hash or enqueue a new job for an existing session.
@@ -181,10 +359,18 @@ class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
         )
 
     async def get_status(self):
-        """Get all pending tasks."""
+        """Get the current import status for the given folder(s).
 
-        params = await request.get_json()
-        folder_hashes, folder_paths = pop_folder_params(params)
+        Without any params, returns the status of all folders.
+        """
+
+        folder_hashes = request.args.getlist("folder_hash")
+        folder_paths = request.args.getlist("folder_path")
+
+        if len(folder_hashes) != len(folder_paths):
+            raise InvalidUsageException(
+                "Provide the same number of folder hashes and paths", status_code=400
+            )
 
         stats: list[FolderStatusUpdate] = []
 

--- a/backend/beets_flask/server/routes/db_models/session.py
+++ b/backend/beets_flask/server/routes/db_models/session.py
@@ -183,6 +183,8 @@ class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
                 # auto-generating overlapping-table aliases.
                 album_match = aliased(AlbumMatch, flat=True)
                 track_match = aliased(TrackMatch, flat=True)
+
+                # build the CTE/subquery for ranking
                 best_candidate = (
                     select(
                         SessionStateInDb.folder_hash,
@@ -200,21 +202,23 @@ class SessionAPIBlueprint(ModelAPIBlueprint[SessionStateInDb]):
                         )
                         .label("rn"),
                     )
+                    .select_from(CandidateStateInDb)
                     .join(
                         TaskStateInDb,
-                        CandidateStateInDb.task_id == TaskStateInDb.id,
+                        TaskStateInDb.id == CandidateStateInDb.task_id,
                     )
                     .join(
                         SessionStateInDb,
-                        TaskStateInDb.session_id == SessionStateInDb.id,
+                        SessionStateInDb.id == TaskStateInDb.session_id,
                     )
-                    .where(SessionStateInDb.id.in_(resolved_ids))
-                    .join(Match, CandidateStateInDb.match_id == Match.id)
-                    .join(Distance, Match.distance_id == Distance.id)
+                    .join(Match, Match.id == CandidateStateInDb.match_id)
+                    .join(Distance, Distance.id == Match.distance_id)
+                    # we need outer joins because of the polymorphism of match
                     .outerjoin(album_match, album_match.id == Match.id)
                     .outerjoin(AlbumInfo, AlbumInfo.id == album_match.info_id)
                     .outerjoin(track_match, track_match.id == Match.id)
                     .outerjoin(TrackInfo, TrackInfo.id == track_match.info_id)
+                    .where(SessionStateInDb.id.in_(resolved_ids))
                     .subquery()
                 )
 

--- a/backend/generate_types.py
+++ b/backend/generate_types.py
@@ -11,6 +11,7 @@ from beets_flask.invoker import EnqueueKind
 from beets_flask.invoker.enqueue import (
     Search,
 )
+from beets_flask.server.routes.db_models.session import MinimalSession
 from beets_flask.server.routes.inbox import InboxStats
 from beets_flask.server.routes.library.resources import (
     AlbumResponse,
@@ -42,6 +43,9 @@ builder = TSBuilder()
 
 # Session state
 builder.add(SerializedSessionState)
+
+# Best-match chip info per folder
+builder.add(MinimalSession)
 
 # ------------------------------- inbox routes ------------------------------- #
 

--- a/backend/tests/integration/test_routes/test_session_minimal.py
+++ b/backend/tests/integration/test_routes/test_session_minimal.py
@@ -1,0 +1,170 @@
+"""Integration tests for the custom `/api_v1/session/minimal` endpoint."""
+
+from pathlib import Path
+from typing import TypedDict
+
+import pytest
+from quart import Response
+from quart.typing import TestClientProtocol as Client
+from sqlalchemy.orm import Session
+
+from beets_flask.database.models.match import AlbumInfo, AlbumMatch, Distance
+from beets_flask.database.models.states import (
+    CandidateStateInDb,
+    FolderInDb,
+    SessionStateInDb,
+    TaskStateInDb,
+)
+from tests.mixins.database import IsolatedDBMixin
+
+
+class Candidate(TypedDict):
+    raw_distance: float
+    max_distance: float
+    duplicate_ids: list[str]
+    data_source: str
+
+
+def make_session(
+    db_session: Session,
+    folder: Path,
+    *,
+    folder_hash: str,
+    candidates: list[Candidate],
+) -> SessionStateInDb:
+    task = TaskStateInDb(paths=[b"a path"], toppath=b"top path")
+    session = SessionStateInDb(
+        folder=FolderInDb(path=folder, hash=folder_hash),
+        tasks=[task],
+    )
+
+    task.candidates = [
+        CandidateStateInDb(
+            match=AlbumMatch(
+                info=AlbumInfo(data={"data_source": candidate["data_source"]}),
+                distance=Distance(
+                    raw_distance=candidate["raw_distance"],
+                    max_distance=candidate["max_distance"],
+                ),
+            ),
+            task=task,
+            duplicate_ids=candidate["duplicate_ids"],
+        )
+        for candidate in candidates
+    ]
+
+    db_session.add(session)
+    db_session.commit()
+    return session
+
+
+async def get_minimal(
+    client: Client,
+    *,
+    folder_hash: str,
+    folder_path: str,
+) -> Response:
+    return await client.get(
+        "/api_v1/session/minimal",
+        query_string={
+            "folder_hash": folder_hash,
+            "folder_path": folder_path,
+        },
+    )
+
+
+class TestSessionMinimalEndpoint(IsolatedDBMixin):
+    async def test_missing_folder_hash_returns_400(self, client: Client):
+        response = await client.get("/api_v1/session/minimal")
+
+        assert response.status_code == 400
+        assert "at least one folder hash" in (await response.get_json())["message"]
+
+    async def test_unknown_folder_returns_empty_response(self, client: Client):
+        response = await get_minimal(
+            client,
+            folder_hash="unknown-hash",
+            folder_path="/does/not/exist",
+        )
+
+        assert response.status_code == 200
+        assert await response.get_json() == {}
+
+    async def test_returns_best_candidate_for_session(
+        self,
+        client: Client,
+        db_session: Session,
+        tmp_path: Path,
+    ):
+        folder = tmp_path / "folder_a"
+        session = make_session(
+            db_session,
+            folder,
+            folder_hash="hash-a",
+            candidates=[
+                {
+                    "raw_distance": 9.0,
+                    "max_distance": 10.0,
+                    "duplicate_ids": ["11", "22"],
+                    "data_source": "musicbrainz",
+                },
+                {
+                    "raw_distance": 1.0,
+                    "max_distance": 10.0,
+                    "duplicate_ids": ["33"],
+                    "data_source": "spotify",
+                },
+            ],
+        )
+
+        response = await get_minimal(
+            client,
+            folder_hash="hash-a",
+            folder_path=str(folder),
+        )
+
+        assert response.status_code == 200
+        assert await response.get_json() == {
+            "hash-a": {
+                "session_id": session.id,
+                "folder_hash": "hash-a",
+                "best_candidate": {
+                    "duplicates": [33],
+                    "distance": pytest.approx(0.1),
+                    "data_source": "spotify",
+                },
+            }
+        }
+
+    async def test_resolves_by_path_when_hash_changed(
+        self,
+        client: Client,
+        db_session: Session,
+        tmp_path: Path,
+    ):
+        folder = tmp_path / "folder_c"
+        session = make_session(
+            db_session,
+            folder,
+            folder_hash="old-hash",
+            candidates=[
+                {
+                    "raw_distance": 1.0,
+                    "max_distance": 10.0,
+                    "duplicate_ids": ["5"],
+                    "data_source": "spotify",
+                },
+            ],
+        )
+
+        response = await get_minimal(
+            client,
+            folder_hash="new-hash",
+            folder_path=str(folder),
+        )
+
+        assert response.status_code == 200
+        entry = (await response.get_json())["new-hash"]
+
+        assert entry["session_id"] == session.id
+        assert entry["folder_hash"] == "old-hash"

--- a/backend/tests/unit/test_disk.py
+++ b/backend/tests/unit/test_disk.py
@@ -87,6 +87,8 @@ def s_base(tmpdir_factory):
     # but with the default config, hidden files should be ignored:
     os.makedirs(os.path.join(base, "artist/album_junk"))
     touch(os.path.join(base, "artist/album_junk/.junk.jpg"))
+    # non-hidden junk must not make the folder an album either
+    touch(os.path.join(base, "artist/album_junk/foo.txt"))
 
     # the annoying rogue element (same as nested folders, but with a rogue file)
     os.makedirs(os.path.join(base, "artist/album_rogue/CD1"))

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
     beets-flask:
-        image: pspitzner/beets-flask:stable
+        image: metasauce/beets-flask:stable
         restart: unless-stopped
         ports:
             - "5001:5001"

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -12,11 +12,11 @@ build:
     python: "3.12"
   jobs:
     create_environment:
+      # Note: each command might run in a separate shell
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - cd backend
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --project backend --all-extras --group docs
     install:
       - "true"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,11 +63,11 @@ html_theme_options = {
         "color-brand-content": "#dee2e6",
     },
     # Sources for editing
-    "source_view_link": "https://github.com/pspitzner/beets-flask/blob/main/docs/{filename}",
+    "source_view_link": "https://github.com/metasauce/beets-flask/blob/main/docs/{filename}",
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/pspitzner/beets-flask",
+            "url": "https://github.com/metasauce/beets-flask",
             "html": """
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
             """,

--- a/docs/develop/contribution.md
+++ b/docs/develop/contribution.md
@@ -6,19 +6,19 @@ We are always happy to see new contributors! If small or large, every contributi
 
 Some technical knowledge for the following tools is required to get started with the project. If you are not familiar with them, please check out the documentation for each tool and make sure you have them installed.
 
--   [Docker](https://docs.docker.com/get-started/)
--   [Docker Compose](https://docs.docker.com/compose/)
--   [Python](https://www.python.org/downloads/) 3.10 or higher
--   [Node.js](https://nodejs.org/en/download/) 18 or higher
--   [git](https://git-scm.com/downloads)
--   [pnpm](https://pnpm.io/installation) (or any other package manager)
+- [Docker](https://docs.docker.com/get-started/)
+- [Docker Compose](https://docs.docker.com/compose/)
+- [Python](https://www.python.org/downloads/) 3.10 or higher
+- [Node.js](https://nodejs.org/en/download/) 18 or higher
+- [git](https://git-scm.com/downloads)
+- [pnpm](https://pnpm.io/installation) (or any other package manager)
 
 ## Setting Up the Development Environment
 
 1. **Clone the repository:**
 
 ```bash
-git clone https://github.com/pSpitzner/beets-flask
+git clone https://github.com/metasauce/beets-flask
 cd beets-flask
 ```
 
@@ -93,7 +93,7 @@ Fork the repository and create a new branch for your changes. Feel free to follo
 ## Example docker compose
 
 ```bash
-git clone https://github.com/pSpitzner/beets-flask.git ./beets_flask_dev
+git clone https://github.com/metasauce/beets-flask.git ./beets_flask_dev
 cd ./beets_flask_dev
 mkdir local
 ```

--- a/docs/develop/resources/docker.md
+++ b/docs/develop/resources/docker.md
@@ -1,10 +1,10 @@
 # Docker
 
-We use docker for containerization and deployment of our application. You can find the files needed to build the docker images in the [`docker`](https://github.com/pSpitzner/beets-flask/tree/main/docker) folder.
+We use docker for containerization and deployment of our application. You can find the files needed to build the docker images in the [`docker`](https://github.com/metasauce/beets-flask/tree/main/docker) folder.
 
 Redis-Caching seems to be very persistent and we have not figured out how to completely reset it without _rebuilding_ the container.
 Thus, currently, after code changes that run inside a redis worker `docker-compose up --build` is needed even when live-mounting the repo.
 
 ## Entrypoints
 
-We use different entrypoints for the different environments. You can find all scripts in the [`docker/entrypoints`](https://github.com/pSpitzner/beets-flask/tree/main/docker/entrypoints) folder.
+We use different entrypoints for the different environments. You can find all scripts in the [`docker/entrypoints`](https://github.com/metasauce/beets-flask/tree/main/docker/entrypoints) folder.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ cd beets-flask
 2. Download the `docker-compose.yaml` file or create it manually and copy the content from below.
 
 ```bash
-wget https://raw.githubusercontent.com/pspitzner/beets-flask/main/docker/docker-compose.yaml
+wget https://raw.githubusercontent.com/metasauce/beets-flask/main/docker/docker-compose.yaml
 ```
 
 If you want to create it manually, you can use the following content:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,8 +7,9 @@ We try to be feature-complete with respect to beets, but there are some limitati
 You might be tempted to import a large existing library (not previously tagged in beets) all at once by moving it into the inbox folder. Currently, once you hit some hundred folder or so, this will get laggy, due to some frontend-logic we have not optimized yet.
 
 Some possible workarounds have been discussed in the following issues:
-- [#164](https://github.com/pSpitzner/beets-flask/issues/164)
-- [#175](https://github.com/pSpitzner/beets-flask/issues/175)
+
+- [#164](https://github.com/metasauce/beets-flask/issues/164)
+- [#175](https://github.com/metasauce/beets-flask/issues/175)
 
 ## Singletons are not supported (wont fix)
 
@@ -19,7 +20,8 @@ While these exceptions (likely) meant acceptable extra effort when beets was ori
 The simple workaround is to place individual files in their own folder (or zip them).
 
 See also:
-- [#186](https://github.com/pSpitzner/beets-flask/issues/186#issuecomment-3201103451)
+
+- [#186](https://github.com/metasauce/beets-flask/issues/186#issuecomment-3201103451)
 
 ## Only the import option `copy` is supported
 
@@ -27,8 +29,8 @@ In order to provide an easy way to correct automatic imports that went wrong, it
 We are thinking about workarounds that add back the convenience of automatic deletion.
 
 See also:
-- [#193](https://github.com/pSpitzner/beets-flask/issues/193)
 
+- [#193](https://github.com/metasauce/beets-flask/issues/193)
 
 ## Upload via webfrontend only supports files
 

--- a/docs/plugins/supported-plugins.md
+++ b/docs/plugins/supported-plugins.md
@@ -1,9 +1,8 @@
 # Compatibility
 
-
 ```{tip}
 If a plugin works for you or doesn't, consider
-[opening an issue or a PR](https://github.com/pspitzner/beets-flask) to add it to the
+[opening an issue or a PR](https://github.com/metasauce/beets-flask) to add it to the
 compatible or incompatible list.
 ```
 
@@ -37,23 +36,22 @@ Enabled by default.
 
 Plugins confirmed to work. No dedicated UI integration, but function correctly.
 
-| Plugin | Description |
-|--------|-------------|
-| [fetchart](https://docs.beets.io/en/latest/plugins/fetchart.html) | Fetch album artwork from multiple sources |
-| [embedart](https://docs.beets.io/en/latest/plugins/embedart.html) | Embed fetched artwork into audio files |
-| [the](https://docs.beets.io/en/latest/plugins/the.html) | Move articles to end of names |
-| [ftintitle](https://docs.beets.io/en/latest/plugins/ftintitle.html) | Move featured artists to title |
-| [lastgenre](https://docs.beets.io/en/latest/plugins/lastgenre.html) | Fetch genres from Last.fm |
-| [albumtypes](https://docs.beets.io/en/latest/plugins/albumtypes.html) | Add album type info |
-| [scrub](https://docs.beets.io/en/latest/plugins/scrub.html) | Clean extraneous tags |
-| [zero](https://docs.beets.io/en/latest/plugins/zero.html) | Null fields to reduce clutter |
-| [convert](https://docs.beets.io/en/latest/plugins/convert.html) | Transcode audio files |
-| [fromfilename](https://docs.beets.io/en/latest/plugins/fromfilename.html) | Guess metadata from filename |
-| [inline](https://docs.beets.io/en/latest/plugins/inline.html) | Use Python snippets in templates |
-| [edit](https://docs.beets.io/en/latest/plugins/edit.html) | Edit metadata via external editor |
-| [discogs](https://docs.beets.io/en/latest/plugins/discogs.html) | Match against Discogs |
-| [keyfinder](https://docs.beets.io/en/latest/plugins/keyfinder.html) | Detect musical key (requires compilation) |
-
+| Plugin                                                                    | Description                               |
+| ------------------------------------------------------------------------- | ----------------------------------------- |
+| [fetchart](https://docs.beets.io/en/latest/plugins/fetchart.html)         | Fetch album artwork from multiple sources |
+| [embedart](https://docs.beets.io/en/latest/plugins/embedart.html)         | Embed fetched artwork into audio files    |
+| [the](https://docs.beets.io/en/latest/plugins/the.html)                   | Move articles to end of names             |
+| [ftintitle](https://docs.beets.io/en/latest/plugins/ftintitle.html)       | Move featured artists to title            |
+| [lastgenre](https://docs.beets.io/en/latest/plugins/lastgenre.html)       | Fetch genres from Last.fm                 |
+| [albumtypes](https://docs.beets.io/en/latest/plugins/albumtypes.html)     | Add album type info                       |
+| [scrub](https://docs.beets.io/en/latest/plugins/scrub.html)               | Clean extraneous tags                     |
+| [zero](https://docs.beets.io/en/latest/plugins/zero.html)                 | Null fields to reduce clutter             |
+| [convert](https://docs.beets.io/en/latest/plugins/convert.html)           | Transcode audio files                     |
+| [fromfilename](https://docs.beets.io/en/latest/plugins/fromfilename.html) | Guess metadata from filename              |
+| [inline](https://docs.beets.io/en/latest/plugins/inline.html)             | Use Python snippets in templates          |
+| [edit](https://docs.beets.io/en/latest/plugins/edit.html)                 | Edit metadata via external editor         |
+| [discogs](https://docs.beets.io/en/latest/plugins/discogs.html)           | Match against Discogs                     |
+| [keyfinder](https://docs.beets.io/en/latest/plugins/keyfinder.html)       | Detect musical key (requires compilation) |
 
 ## Incompatible
 

--- a/frontend/src/api/inbox.ts
+++ b/frontend/src/api/inbox.ts
@@ -158,11 +158,25 @@ function deleteFromFolder(
     }
 }
 
-export function* walkFolder(folder: Folder): Generator<FileSystemItem> {
+/**
+ * Depth-first walk over a folder tree.
+ *
+ * @param folder The root folder to walk.
+ * @param depth How many directory levels to descend into. `0` yields only
+ *              the root folder, `1` yields the root and its immediate
+ *              children, etc. Defaults to `Infinity` (full walk).
+ */
+export function* walkFolder(
+    folder: Folder,
+    depth: number = Infinity
+): Generator<FileSystemItem> {
     yield folder;
+    if (depth <= 0) {
+        return;
+    }
     for (const child of folder.children) {
         if (child.type === 'directory') {
-            yield* walkFolder(child as Folder);
+            yield* walkFolder(child as Folder, depth - 1);
         } else {
             yield child;
         }

--- a/frontend/src/api/inbox.ts
+++ b/frontend/src/api/inbox.ts
@@ -11,8 +11,11 @@ import type { FileSystemItem, Folder, InboxStats } from '@/pythonTypes';
 import { APIError, queryClient } from './common';
 
 // Tree of inbox folders
+// Only refetches when explicitly invalidated (file system updates via the
+// socket, or the manual refresh below); the tree itself is static otherwise.
 export const inboxQueryOptions = () => ({
     queryKey: ['inbox'],
+    staleTime: Infinity,
     queryFn: async () => {
         const response = await fetch(`/inbox/tree`);
         return (await response.json()) as Folder[];
@@ -42,6 +45,8 @@ queryClient.setMutationDefaults(['refreshInboxTree'], {
 });
 
 // A specific folder
+// Same staleness contract as the inbox tree: only refetches when the
+// `['inbox']` key is invalidated (file system updates or manual refresh).
 export const inboxFolderQueryOptions = (path: string, hash?: string) => ({
     queryKey: [
         'inbox',
@@ -50,6 +55,7 @@ export const inboxFolderQueryOptions = (path: string, hash?: string) => ({
             hash,
         },
     ],
+    staleTime: Infinity,
     queryFn: async () => {
         const response = await fetch(`/inbox/folder`, {
             method: 'POST',
@@ -68,6 +74,7 @@ export const inboxFolderQueryOptions = (path: string, hash?: string) => ({
 // Some stats about the inbox(es)
 export const inboxStatsQueryOptions = () => ({
     queryKey: ['inbox', 'stats'],
+    staleTime: Infinity,
     queryFn: async () => {
         const response = await fetch(`/inbox/stats`);
         const dat = (await response.json()) as InboxStats[];

--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -477,12 +477,108 @@ async function waitForJobUpdate({
 }
 
 /* ----------------------------- Session status ----------------------------- */
-export const statusQueryOptions = {
-    queryKey: ['status', 'all'],
-    queryFn: async () => {
-        // fetch initial status
-        // further updates will be handled by the socket
-        const response = await fetch('/session/status');
-        return (await response.json()) as FolderStatusUpdate[];
+
+/** Canonical per-folder cache entry for a folder's status.
+ *
+ * Prefer hydrating this via `ensureStatuses` (single batch request);
+ * the queryFn here is the fallback for a lone folder. Stays fresh until
+ * explicitly updated via the status socket.
+ */
+export const statusQueryOptions = (folderHash: string, folderPath: string) => ({
+    queryKey: ['session', folderHash, 'status'],
+    staleTime: Infinity,
+    queryFn: async (): Promise<FolderStatusUpdate | null> => {
+        const params = new URLSearchParams();
+        params.append('folder_hash', folderHash);
+        params.append('folder_path', folderPath);
+        const response = await fetch(`/session/status?${params.toString()}`);
+        const statuses = (await response.json()) as FolderStatusUpdate[];
+        return (
+            statuses.find((status) => status.hash === folderHash) ??
+            statuses.find((status) => status.path === folderPath) ??
+            null
+        );
+    },
+});
+
+/**
+ * Fetch statuses for many folders in a single request and populate each
+ * folder's canonical cache entry. Only folders not cached yet are requested;
+ * folders without a status are cached as null so they are not refetched.
+ */
+export async function ensureStatuses(
+    folders: Array<{ hash: string; path: string }>
+): Promise<void> {
+    const missing = folders.filter(
+        (folder) =>
+            queryClient.getQueryData<FolderStatusUpdate | null>(
+                statusQueryOptions(folder.hash, folder.path).queryKey
+            ) === undefined
+    );
+
+    if (missing.length === 0) {
+        return;
+    }
+
+    const params = new URLSearchParams();
+    missing.forEach((folder) => {
+        params.append('folder_hash', folder.hash);
+        params.append('folder_path', folder.path);
+    });
+    const response = await fetch(`/session/status?${params.toString()}`);
+    const statuses = (await response.json()) as FolderStatusUpdate[];
+    const byHash = new Map<string, FolderStatusUpdate>();
+    const byPath = new Map<string, FolderStatusUpdate>();
+    for (const status of statuses) {
+        if (!byHash.has(status.hash)) {
+            byHash.set(status.hash, status);
+        }
+        if (!byPath.has(status.path)) {
+            byPath.set(status.path, status);
+        }
+    }
+
+    for (const folder of missing) {
+        queryClient.setQueryData<FolderStatusUpdate | null>(
+            statusQueryOptions(folder.hash, folder.path).queryKey,
+            byHash.get(folder.hash) ?? byPath.get(folder.path) ?? null
+        );
+    }
+}
+
+/* -------------------------- Minimal session info -------------------------- */
+
+/** Per-folder cache entry for the best-match chip info.
+ *
+ * Fallback for a single folder; use `ensureMinimalSessionData` for batches.
+ * Stays fresh until invalidated via `invalidateSession`.
+ */
+export const minimalSessionQueryOptions = (
+    folderHash: string,
+    folderPath: string
+) => ({
+    queryKey: ['session', folderHash, 'minimal'],
+    staleTime: Infinity,
+    queryFn: async (): Promise<MinimalSession | null> => {
+        const params = new URLSearchParams();
+        params.append('folder_hash', folderHash);
+        params.append('folder_path', folderPath);
+        const response = await fetch(`/session/minimal?${params.toString()}`);
+        // Returns mapping from given hash to found session
+        // Care! : The MinimalSession does not necessarly have the same folder hash
+        const res = (await response.json()) as Record<string, MinimalSession>;
+
+        for (const folder_hash_org in res) {
+            const session = res[folder_hash_org];
+
+            if (session && session.folder_hash !== folderHash) {
+                queryClient.setQueryData<MinimalSession | null>(
+                    ['session', session.folder_hash, 'minimal'],
+                    session
+                );
+            }
+        }
+
+        return res[folderHash] ?? null;
     },
 };

--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -28,7 +28,7 @@ export const sessionQueryOptions = ({
     folderPath?: string;
 }) => ({
     queryKey: ['session', folderHash, 'full'],
-    StaleTime: Infinity,
+    staleTime: Infinity,
     queryFn: async () => {
         const params = new URLSearchParams();
         params.append('folder_hash', folderHash);

--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -9,6 +9,7 @@ import {
     FolderStatus,
     FolderStatusUpdate,
     JobStatusUpdate,
+    MinimalSession,
     Search,
     SerializedCandidateState,
     SerializedException,
@@ -23,21 +24,18 @@ export const sessionQueryOptions = ({
     folderHash,
     folderPath,
 }: {
-    folderHash?: string;
+    folderHash: string;
     folderPath?: string;
 }) => ({
-    queryKey: ['session', { folderHash, folderPath }],
+    queryKey: ['session', folderHash, 'full'],
+    StaleTime: Infinity,
     queryFn: async () => {
-        const response = await fetch(`/session/by_folder`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                folder_hashes: [folderHash],
-                folder_paths: [folderPath],
-            }),
-        });
+        const params = new URLSearchParams();
+        params.append('folder_hash', folderHash);
+        if (folderPath) {
+            params.append('folder_path', folderPath);
+        }
+        const response = await fetch(`/session/full?${params.toString()}`);
         // make sure we have a folder
         const res = (await response.json()) as
             SerializedSessionState | SerializedException;
@@ -68,10 +66,7 @@ export const sessionQueryOptions = ({
         }
 
         queryClient.setQueryData<SerializedSessionState>(
-            [
-                'session',
-                { folderHash: res.folder_hash, folderPath: res.folder_path },
-            ],
+            ['session', res.folder_hash, 'full'],
             res
         );
 
@@ -81,35 +76,26 @@ export const sessionQueryOptions = ({
 
 /* ------------------------------ Invalidation ------------------------------ */
 
-/** Invalidates all session data which
- * is related to the given folder/session.
+/** Invalidates the cached full session state and minimal chip info for a
+ * given folder hash. Without a hash, invalidates all session data.
  *
- * If a hash is given, this will only invalidate
- * the session with the given hash. Otherwise it will invalidates
- * all sessions with the given path.
+ * Status entries are intentionally excluded: they are updated directly from
+ * socket events (see statusQueryOptions).
  */
-export async function invalidateSession(
-    folderHash?: string,
-    folderPath?: string,
-    strict = false
-): Promise<void> {
-    console.debug('Invalidate session', folderHash, folderPath);
-    await queryClient.invalidateQueries({
-        predicate: (query) => {
-            if (query.queryKey[0] !== 'session') return false;
-            const { folderHash: qHash, folderPath: qPath } = query
-                .queryKey[1] as {
-                folderHash?: string;
-                folderPath?: string;
-            };
-            // If we have a hash, invalidate only this session
-            if (folderHash && strict) {
-                return qHash == folderHash;
-            }
-            // Otherwise invalidate all sessions with the given path
-            return qPath == folderPath || qHash == folderHash;
-        },
-    });
+export async function invalidateSession(folderHash?: string): Promise<void> {
+    console.debug('Invalidate session', folderHash);
+    if (!folderHash) {
+        await queryClient.invalidateQueries({ queryKey: ['session'] });
+        return;
+    }
+    await Promise.all([
+        queryClient.invalidateQueries({
+            queryKey: ['session', folderHash, 'full'],
+        }),
+        queryClient.invalidateQueries({
+            queryKey: ['session', folderHash, 'minimal'],
+        }),
+    ]);
 }
 
 /* -------------------------------- Mutations ------------------------------- */
@@ -206,57 +192,32 @@ export const enqueueMutationOptions: UseMutationOptions<
     },
     // Optimistic update for status, show pending before backend response
     onMutate: async ({ selected }) => {
-        const queryKey = statusQueryOptions.queryKey;
-        await queryClient.cancelQueries({ queryKey });
-
-        queryClient.setQueryData<FolderStatusUpdate[]>(queryKey, (old) => {
-            if (!old) return old;
-            const found = new Set();
-            let nex = structuredClone(old);
-            nex = nex.map((status) => {
-                if (selected.hashes.includes(status.hash)) {
-                    status.status = FolderStatus.PENDING;
-                    status.exc = null;
-                    found.add(status.hash);
-                }
-                return status;
+        for (const [idx, hash] of selected.hashes.entries()) {
+            const queryKey = statusQueryOptions(
+                hash,
+                selected.paths[idx]
+            ).queryKey;
+            await queryClient.cancelQueries({ queryKey });
+            queryClient.setQueryData<FolderStatusUpdate>(queryKey, {
+                path: selected.paths[idx],
+                hash: hash,
+                status: FolderStatus.PENDING,
+                exc: null,
+                event: 'folder_status_update',
             });
-            for (const hash of selected.hashes) {
-                if (!found.has(hash)) {
-                    nex.push({
-                        path: selected.paths[selected.hashes.indexOf(hash)],
-                        hash: hash,
-                        status: FolderStatus.PENDING,
-                        exc: null,
-                        event: 'folder_status_update',
-                    });
-                }
-            }
-            return nex;
-        });
+        }
     },
     // Fetch new session on success
     onSuccess: async (_data, { selected }) => {
         const predicate = (query: Query) => {
             if (query.queryKey[0] == 'artists') return true;
             if (query.queryKey[0] !== 'session') return false;
-            if (!query.queryKey[1]) return false;
-            // Lets just invalidate all session with this path or hash
-            const { folderHash: qHash, folderPath: qPath } = query
-                .queryKey[1] as {
-                folderHash?: string;
-                folderPath?: string;
-            };
-
-            let containsPath = false;
-            let containsHash = false;
-            if (qPath && selected.paths.length > 0) {
-                containsPath = selected.paths.includes(qPath);
-            }
-            if (qHash && selected.hashes.length > 0) {
-                containsHash = selected.hashes.includes(qHash);
-            }
-            return containsPath || containsHash;
+            // Covers 'full' and 'minimal' entries for a folder hash.
+            // 'status' is updated directly via the socket, not refetched here.
+            return (
+                query.queryKey[2] !== 'status' &&
+                selected.hashes.includes(query.queryKey[1] as string)
+            );
         };
 
         const ps = [
@@ -581,4 +542,39 @@ export const minimalSessionQueryOptions = (
 
         return res[folderHash] ?? null;
     },
-};
+});
+
+/**
+ * Fetch minimal chip info for many folders in one request and populate their
+ * canonical cache entries. Skips cached folders; caches null for folders
+ * without a session so they are not refetched.
+ */
+export async function ensureMinimalSessions(
+    folders: Array<{ hash: string; path: string }>
+): Promise<void> {
+    const missing = folders.filter(
+        (folder) =>
+            queryClient.getQueryData<MinimalSession | null>(
+                minimalSessionQueryOptions(folder.hash, folder.path).queryKey
+            ) === undefined
+    );
+
+    if (missing.length === 0) {
+        return;
+    }
+
+    const params = new URLSearchParams();
+    missing.forEach((folder) => {
+        params.append('folder_hash', folder.hash);
+        params.append('folder_path', folder.path);
+    });
+    const response = await fetch(`/session/minimal?${params.toString()}`);
+    const res = (await response.json()) as Record<string, MinimalSession>;
+
+    missing.forEach((folder) => {
+        queryClient.setQueryData<MinimalSession | null>(
+            minimalSessionQueryOptions(folder.hash, folder.path).queryKey,
+            res[folder.hash] ?? null
+        );
+    });
+}

--- a/frontend/src/components/common/chips.tsx
+++ b/frontend/src/components/common/chips.tsx
@@ -6,15 +6,14 @@
  */
 
 import { FolderClockIcon } from 'lucide-react';
-import { useMemo } from 'react';
 import { Box, darken, styled, Tooltip, useTheme } from '@mui/material';
 import Chip, { ChipProps } from '@mui/material/Chip';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 
 import { useConfig } from '@/api/config';
-import { sessionQueryOptions, statusQueryOptions } from '@/api/session';
-import { Archive, Folder, FolderStatus, Progress } from '@/pythonTypes';
+import { minimalSessionQueryOptions, statusQueryOptions } from '@/api/session';
+import { Archive, Folder, FolderStatus } from '@/pythonTypes';
 
 import {
     FolderStatusIcon,
@@ -165,42 +164,43 @@ export function DuplicateChip({
     ...props
 }: { folder: Folder | Archive } & ChipProps) {
     const theme = useTheme();
-    const { data: session } = useQuery(
-        sessionQueryOptions({ folderPath: folder.full_path })
+    const { data: minimalSession } = useQuery(
+        minimalSessionQueryOptions(folder.hash, folder.full_path)
     );
 
-    //Fixme: Generalize best candidate
-    const bestCandidate = session?.tasks
-        .flatMap((t) => t.candidates.map((c) => c))
-        .filter((c) => c.info.data_source !== 'asis')
-        .sort((a, b) => a.distance - b.distance)[0];
-
-    if (!bestCandidate) {
+    if (
+        !minimalSession ||
+        minimalSession.best_candidate.duplicates.length == 0
+    ) {
         return null;
     }
 
-    if (bestCandidate.duplicate_ids.length == 0) {
-        return null;
-    }
-
-    if (session.status.progress >= Progress.IMPORT_COMPLETED) {
-        return null;
-    }
+    // FIXME: we currently only show one duplicate batch although the best candidate
+    // could have multiple duplicates.
     return (
         <Tooltip title="This album is already in your beets library!">
-            <StyledChip
-                icon={
-                    <PenaltyTypeIcon
-                        type="duplicate"
-                        size={theme.iconSize.sm - 2}
-                    />
-                }
-                label="Duplicate"
-                size="small"
-                color="error"
-                variant="outlined"
-                {...props}
-            />
+            <Link
+                to={'/library/album/$albumId'}
+                params={{
+                    albumId: minimalSession.best_candidate.duplicates[0],
+                }}
+                preload="intent"
+                style={{ gridColumn: 'chip' }}
+            >
+                <StyledChip
+                    icon={
+                        <PenaltyTypeIcon
+                            type="duplicate"
+                            size={theme.iconSize.sm - 2}
+                        />
+                    }
+                    label="Duplicate"
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    {...props}
+                />
+            </Link>
         </Tooltip>
     );
 }
@@ -212,13 +212,10 @@ export function FolderStatusChip({
     folder,
     ...props
 }: { folder: Folder | Archive } & ChipProps) {
-    const { data: statuses } = useQuery(statusQueryOptions);
+    const { data: folderStatus } = useQuery(
+        statusQueryOptions(folder.hash, folder.full_path)
+    );
     const theme = useTheme();
-
-    // Status enum value
-    const folderStatus = useMemo(() => {
-        return statuses?.find((s) => s.path === folder.full_path);
-    }, [statuses, folder.full_path]);
 
     if (!folderStatus) {
         return null;
@@ -292,26 +289,18 @@ export function BestCandidateChip({
     folder,
     ...props
 }: { folder: Folder | Archive } & ChipProps) {
-    // FIXME: Fetching the full session here is kinda overkill
-    // Only use path here, and
-    // TODO: add hash inconsistency warning badge!
-    const { data: session } = useQuery(
-        sessionQueryOptions({ folderPath: folder.full_path })
+    const { data: minimalSession } = useQuery(
+        minimalSessionQueryOptions(folder.hash, folder.full_path)
     );
 
-    const bestCandidate = session?.tasks
-        .flatMap((t) => t.candidates.map((c) => c))
-        .filter((c) => c.info.data_source !== 'asis')
-        .sort((a, b) => a.distance - b.distance)[0];
-
-    if (!bestCandidate || !bestCandidate.info.data_source) {
+    if (!minimalSession) {
         return null;
     }
 
     return (
         <MatchChip
-            source={bestCandidate.info.data_source}
-            distance={bestCandidate.distance}
+            source={minimalSession.best_candidate.data_source}
+            distance={minimalSession.best_candidate.distance}
             {...props}
         />
     );
@@ -327,15 +316,14 @@ export function HashMismatchChip({
     ...props
 }: { folder: Folder | Archive } & ChipProps) {
     const theme = useTheme();
-    const { data: session } = useQuery(
-        sessionQueryOptions({ folderPath: folder.full_path })
+    const { data: minimalSession } = useQuery(
+        minimalSessionQueryOptions(folder.hash, folder.full_path)
     );
 
-    if (!session) {
-        return null;
-    }
-
-    if (session.folder_hash == folder.hash) {
+    if (
+        !minimalSession?.folder_hash ||
+        minimalSession.folder_hash === folder.hash
+    ) {
         return null;
     }
 

--- a/frontend/src/components/common/chips.tsx
+++ b/frontend/src/components/common/chips.tsx
@@ -217,7 +217,10 @@ export function FolderStatusChip({
     );
     const theme = useTheme();
 
-    if (!folderStatus) {
+    /*
+    Only report folders that have a status; unkown means no session
+    */
+    if (!folderStatus || folderStatus.status == FolderStatus.UNKNOWN) {
         return null;
     }
 

--- a/frontend/src/components/common/websocket/status.tsx
+++ b/frontend/src/components/common/websocket/status.tsx
@@ -38,36 +38,14 @@ export function StatusContextProvider({
 
         function handleFolderStatusUpdate(updateData: FolderStatusUpdate) {
             console.log('FolderStatusUpdate', updateData);
-            // update folder status
-            queryClient.setQueryData<FolderStatusUpdate[]>(
-                statusQueryOptions.queryKey,
-                (prev) => {
-                    if (!prev) return [updateData];
-                    const n = [...prev];
-
-                    // If the folder is already in the list, update it
-                    let folderIndex = n.findIndex((folder) => {
-                        return folder.hash === updateData.hash;
-                    });
-                    if (folderIndex !== -1) {
-                        // Try by path if we did not find it by hash
-                        folderIndex = n.findIndex((folder) => {
-                            return folder.path === updateData.path;
-                        });
-                    }
-
-                    if (folderIndex !== -1) {
-                        n[folderIndex] = updateData;
-                    } else {
-                        n.push(updateData);
-                    }
-                    return n;
-                }
+            // Update the folder's status directly; further data (session state,
+            // duplicates) is refetched via invalidation.
+            queryClient.setQueryData<FolderStatusUpdate>(
+                statusQueryOptions(updateData.hash, updateData.path).queryKey,
+                updateData
             );
 
-            invalidateSession(updateData.hash, updateData.path, false).catch(
-                console.error
-            );
+            invalidateSession(updateData.hash).catch(console.error);
         }
 
         async function handleFileSystemUpdate(updateData: FileSystemUpdate) {

--- a/frontend/src/components/inbox/cards/inboxCard.tsx
+++ b/frontend/src/components/inbox/cards/inboxCard.tsx
@@ -14,7 +14,7 @@ import {
     useInboxFolderFrontendConfig,
 } from '@/api/config';
 import { walkFolder } from '@/api/inbox';
-import { sessionQueryOptions } from '@/api/session';
+import { statusQueryOptions } from '@/api/session';
 import { InboxTypeIcon } from '@/components/common/icons';
 import { CardHeader } from '@/components/frontpage/statsCard';
 import {
@@ -24,7 +24,7 @@ import {
     GridWrapper,
     InboxGridHeader,
 } from '@/components/inbox/fileTree';
-import { Archive, Folder, Progress } from '@/pythonTypes';
+import { Archive, Folder, FolderStatus } from '@/pythonTypes';
 
 import { InboxActions } from '../actions/buttons';
 
@@ -58,33 +58,28 @@ export const useInboxCardContext = () => {
 };
 
 /** Given a folder get all subfolders
- * that have been imported (i.e. have a session with `status.progress` equal to `Progress.IMPORT_COMPLETED`).
+ * that have been imported (i.e. have a status of `FolderStatus.IMPORTED`).
+ *
+ * Each subfolder's status is read from its canonical cache entry
+ * (`statusQueryOptions`), which the inbox route loader batch-hydrates via
+ * `ensureStatuses` and the status socket keeps up to date.
  */
 function useImportedFolders(folder: Folder) {
-    const folders = useMemo(() => {
-        const fs = [];
-        for (const f of walkFolder(folder)) {
-            if (f.type === 'file') continue; // skip files
-            if (f.full_path === folder.full_path) continue; // skip the root folder
-            fs.push(f);
-        }
-        return fs;
-    }, [folder]);
+    const folders = useMemo(
+        () =>
+            [...walkFolder(folder)].filter(
+                (f) => f.type !== 'file' && f.full_path !== folder.full_path
+            ),
+        [folder]
+    );
 
-    const sessions = useQueries({
-        queries: folders.map((f) =>
-            sessionQueryOptions({ folderHash: f.hash, folderPath: f.full_path })
-        ),
+    const statuses = useQueries({
+        queries: folders.map((f) => statusQueryOptions(f.hash, f.full_path)),
     });
 
-    const importedFolders = useMemo(() => {
-        return folders.filter((f, i) => {
-            const session = sessions[i];
-            return session.data?.status.progress === Progress.IMPORT_COMPLETED;
-        });
-    }, [folders, sessions]);
-
-    return importedFolders;
+    return folders.filter(
+        (f, i) => statuses[i].data?.status === FolderStatus.IMPORTED
+    );
 }
 
 export function InboxCardProvider({

--- a/frontend/src/errors.tsx
+++ b/frontend/src/errors.tsx
@@ -207,7 +207,7 @@ export function GenericErrorCard({
                         sx={{ color: 'text.secondary', marginTop: '0.2rem' }}
                     >
                         If this is a reoccurring issue, feel free to raise an{' '}
-                        <Link href="https://github.com/pSpitzner/beets-flask/issues">
+                        <Link href="https://github.com/metasauce/beets-flask/issues">
                             issue on GitHub
                         </Link>
                         .

--- a/frontend/src/pythonTypes.ts
+++ b/frontend/src/pythonTypes.ts
@@ -5,6 +5,7 @@
  */
 export type File = FileSystemItem;
 
+
 export interface SerializedSessionState {
     id: string;
     created_at: Date;
@@ -28,6 +29,18 @@ export interface Search {
     search_name: null | string;
 }
 
+export interface MinimalSession {
+    session_id: string;
+    folder_hash: string;
+    best_candidate: MinimalBestCandidateInfo;
+}
+
+export interface MinimalBestCandidateInfo {
+    data_source: string;
+    distance: number;
+    duplicates: Array<number>;
+}
+
 export interface LibraryStats {
     libraryPath: string;
     items: number;
@@ -46,7 +59,7 @@ export interface JobStatusUpdate {
     num_jobs: number;
     job_metas: Array<JobMeta>;
     exc: SerializedException | null;
-    event: 'job_status_update';
+    event: "job_status_update";
 }
 
 export interface InboxStats {
@@ -64,7 +77,7 @@ export interface FolderStatusUpdate {
     hash: string;
     status: FolderStatus;
     exc: SerializedException | null;
-    event: 'folder_status_update';
+    event: "folder_status_update";
 }
 
 export interface Folder extends FileSystemItem {
@@ -73,7 +86,7 @@ export interface Folder extends FileSystemItem {
 
 export interface FileSystemUpdate {
     exc: SerializedException | null;
-    event: 'file_system_update';
+    event: "file_system_update";
 }
 
 export interface MatchSectionSchema {
@@ -87,9 +100,9 @@ export interface ImportDuplicateKeys {
 }
 
 export interface ImportSection {
-    duplicate_action: 'ask' | 'keep' | 'merge' | 'remove' | 'skip';
-    move: 'False';
-    copy: 'True';
+    duplicate_action: "ask" | "keep" | "merge" | "remove" | "skip";
+    move: "False";
+    copy: "True";
     duplicate_keys: ImportDuplicateKeys;
 }
 
@@ -113,7 +126,7 @@ export interface LibrarySectionSchema {
 }
 
 export interface InboxSectionSchema {
-    ignore: '_use_beets_ignore' | Array<string>;
+    ignore: "_use_beets_ignore" | Array<string>;
     debounce_before_autotag: number;
     temp_dir: string;
     folders: Record<string, InboxFolderSchema>;
@@ -234,7 +247,7 @@ export interface InboxFolderSchema {
     path: string;
     name: string;
     auto_threshold: null | number;
-    autotag: 'auto' | 'bootleg' | 'off' | 'preview';
+    autotag: "auto" | "bootleg" | "off" | "preview";
 }
 
 export interface Metadata {
@@ -340,7 +353,7 @@ export interface ItemResponse {
 }
 
 export interface MusicInfo {
-    type: 'album' | 'item' | 'track';
+    type: "album" | "item" | "track";
     artist: null | string;
     album: null | string;
     data_url: null | string;
@@ -361,7 +374,7 @@ export interface ItemInfo extends MusicInfo {
 }
 
 export interface FileSystemItem {
-    type: 'archive' | 'directory' | 'file';
+    type: "archive" | "directory" | "file";
     full_path: string;
     hash: string;
     is_album: boolean;
@@ -390,3 +403,4 @@ export interface AlbumInfo extends MusicInfo {
     catalognum: null | string;
     albumdisambig: null | string;
 }
+

--- a/frontend/src/pythonTypes.ts
+++ b/frontend/src/pythonTypes.ts
@@ -5,7 +5,6 @@
  */
 export type File = FileSystemItem;
 
-
 export interface SerializedSessionState {
     id: string;
     created_at: Date;
@@ -59,7 +58,7 @@ export interface JobStatusUpdate {
     num_jobs: number;
     job_metas: Array<JobMeta>;
     exc: SerializedException | null;
-    event: "job_status_update";
+    event: 'job_status_update';
 }
 
 export interface InboxStats {
@@ -77,7 +76,7 @@ export interface FolderStatusUpdate {
     hash: string;
     status: FolderStatus;
     exc: SerializedException | null;
-    event: "folder_status_update";
+    event: 'folder_status_update';
 }
 
 export interface Folder extends FileSystemItem {
@@ -86,7 +85,7 @@ export interface Folder extends FileSystemItem {
 
 export interface FileSystemUpdate {
     exc: SerializedException | null;
-    event: "file_system_update";
+    event: 'file_system_update';
 }
 
 export interface MatchSectionSchema {
@@ -100,9 +99,9 @@ export interface ImportDuplicateKeys {
 }
 
 export interface ImportSection {
-    duplicate_action: "ask" | "keep" | "merge" | "remove" | "skip";
-    move: "False";
-    copy: "True";
+    duplicate_action: 'ask' | 'keep' | 'merge' | 'remove' | 'skip';
+    move: 'False';
+    copy: 'True';
     duplicate_keys: ImportDuplicateKeys;
 }
 
@@ -126,7 +125,7 @@ export interface LibrarySectionSchema {
 }
 
 export interface InboxSectionSchema {
-    ignore: "_use_beets_ignore" | Array<string>;
+    ignore: '_use_beets_ignore' | Array<string>;
     debounce_before_autotag: number;
     temp_dir: string;
     folders: Record<string, InboxFolderSchema>;
@@ -247,7 +246,7 @@ export interface InboxFolderSchema {
     path: string;
     name: string;
     auto_threshold: null | number;
-    autotag: "auto" | "bootleg" | "off" | "preview";
+    autotag: 'auto' | 'bootleg' | 'off' | 'preview';
 }
 
 export interface Metadata {
@@ -353,7 +352,7 @@ export interface ItemResponse {
 }
 
 export interface MusicInfo {
-    type: "album" | "item" | "track";
+    type: 'album' | 'item' | 'track';
     artist: null | string;
     album: null | string;
     data_url: null | string;
@@ -374,7 +373,7 @@ export interface ItemInfo extends MusicInfo {
 }
 
 export interface FileSystemItem {
-    type: "archive" | "directory" | "file";
+    type: 'archive' | 'directory' | 'file';
     full_path: string;
     hash: string;
     is_album: boolean;
@@ -403,4 +402,3 @@ export interface AlbumInfo extends MusicInfo {
     catalognum: null | string;
     albumdisambig: null | string;
 }
-

--- a/frontend/src/routes/_frontpage/index.tsx
+++ b/frontend/src/routes/_frontpage/index.tsx
@@ -211,7 +211,7 @@ function Footer() {
                 <Typography variant="caption">&nbsp;Documentation</Typography>
             </Link>
             <Link
-                href="https://github.com/pSpitzner/beets-flask"
+                href="https://github.com/metasauce/beets-flask"
                 target="_blank"
                 variant="body2"
             >
@@ -219,7 +219,7 @@ function Footer() {
                 <Typography variant="caption">&nbsp;GitHub</Typography>
             </Link>
             <Link
-                href="https://github.com/pSpitzner/beets-flask/issues/new"
+                href="https://github.com/metasauce/beets-flask/issues/new"
                 target="_blank"
                 variant="body2"
             >

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -12,7 +12,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { Action, useConfig } from '@/api/config';
-import { inboxQueryOptions } from '@/api/inbox';
+import { inboxQueryOptions, walkFolder } from '@/api/inbox';
+import { ensureMinimalSessions, ensureStatuses } from '@/api/session';
 import { MatchChip, StyledChip } from '@/components/common/chips';
 import { Dialog } from '@/components/common/dialogs';
 import {
@@ -31,14 +32,42 @@ import { InboxCard } from '@/components/inbox/cards/inboxCard';
 import { FileUploadProvider } from '@/components/inbox/fileUpload/context';
 import { DropZone } from '@/components/inbox/fileUpload/dropzone';
 import { FolderSelectionProvider } from '@/components/inbox/folderSelectionContext';
-import { Folder } from '@/pythonTypes';
+import { Archive, Folder } from '@/pythonTypes';
 
 /* ---------------------------------- Route --------------------------------- */
 
 export const Route = createFileRoute('/inbox/')({
     component: RouteComponent,
     loader: async ({ context }) => {
-        return await context.queryClient.ensureQueryData(inboxQueryOptions());
+        // Load inboxes
+        const inboxes =
+            await context.queryClient.ensureQueryData(inboxQueryOptions());
+
+        // Filter: all top level folders/archives in inboxes
+        const prefetch_folders: Array<Folder | Archive> = [];
+        for (const inbox of inboxes) {
+            for (const child of walkFolder(inbox, 1)) {
+                if (child.type === 'directory' || child.type === 'archive') {
+                    prefetch_folders.push(child);
+                }
+            }
+        }
+        // Prefetch minimal information for all sessions within the top level inbox
+        // folders. This prevents waterfall loading states
+        await Promise.all([
+            ensureStatuses(
+                prefetch_folders.map((f) => ({
+                    hash: f.hash,
+                    path: f.full_path,
+                }))
+            ),
+            ensureMinimalSessions(
+                prefetch_folders.map((f) => ({
+                    hash: f.hash,
+                    path: f.full_path,
+                }))
+            ),
+        ]);
     },
 });
 


### PR DESCRIPTION
## Summary

Introduces a lightweight `GET /api_v1/session/minimal` endpoint that returns only the data the frontend chips need (best match, duplicates, data source) in one batched request, instead of loading full session states. The frontend now hydrates the inbox with this minimal data and only fetches full sessions on demand.
**--> Faster initial loading of the inbox!** 

For my currently relative big inbox this decreased loading times from 16s down to under 1s :tada: 


closes #334 

---

Along the way I fixes several related bugs found while refactoring:

- **Stale exceptions survived reimports**: `run_async` now resets the session exception after every successful run, so a previous failure no longer lingers in the DB after a subsequent import.
- **Folders without any status showed "Unknown"/"Not started" badges**: after the refactor we fetch statuses for every folder, and folders without a session or job came back as `UNKNOWN`, surfacing as "Unknown"/"Not started" badges. The status chips now do not show `Unknown` badges anymore
- **Junk folders were detected as albums**: beets' `albums_in_dir` treats any directory containing *any* files as an album. `all_album_folders`/`is_album_folder` now require at least one audio file, so stray uploads (`foo.txt`, …) are no longer incorrectly marked as albums or auto-tagged by the watchdog.


