### PR TITLE
Migration to metsauce org

### DIFF
--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -23,8 +23,8 @@ jobs:
               with:
                   # list of Docker images to use as base name for tags
                   images: |
-                      pspitzner/beets-flask
-                      ghcr.io/pspitzner/beets-flask
+                      metasauce/beets-flask
+                      ghcr.io/metasauce/beets-flask
                   # generate Docker tags based on the following events/attributes
                   # We use semver and allow pre-releases (e.g. v1.0.0-b1 or v1.0.0-rc3) to be tagged as 'latest' for testing purposes
                   # The 'stable' tag is only applied to non-prerelease versions (e.g. v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes ⚠️
 
-- **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/pSpitzner/beets-flask/issues/212)
+- **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/metasauce/beets-flask/issues/212)
 - **Upgraded `beets` from `v2.5.1` to `v2.12.0`**
-    - This contains many changes and improvements, including some plugins.
-    - See the changelog at [beets.readthedocs.io](https://beets.readthedocs.io/en/stable/changelog.html)
+  - This contains many changes and improvements, including some plugins.
+  - See the changelog at [beets.readthedocs.io](https://beets.readthedocs.io/en/stable/changelog.html)
 - Changed config options (beets-flask):
-    - `gui.inbox.folders.your_inbox.autotag` no longer accepts `false`, use `"off"` instead. (This was needed for consistency for the new config validation)
+  - `gui.inbox.folders.your_inbox.autotag` no longer accepts `false`, use `"off"` instead. (This was needed for consistency for the new config validation)
 - Changed config options (beets):
-    - `fetchart.sources` were changed, if you get errors from our previous defaults: change to `"*"`
-
+  - `fetchart.sources` were changed, if you get errors from our previous defaults: change to `"*"`
 
 ### Added
 
-- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
+- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/metasauce/beets-flask/pull/224).
 - Upload Files via the WebUI. You can now drag-and-drop single files into an inbox. To upload whole albums, zip them on your host first (uploading of folders directly is not implemented, as it would require a secure context).
-- New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
-- You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)
-- Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/pSpitzner/beets-flask/pull/277)
+- New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/metasauce/beets-flask/pull/224)
+- You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/metasauce/beets-flask/issues/260)
+- Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/metasauce/beets-flask/pull/277)
 
 ### Fixed
 
-- Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/pSpitzner/beets-flask/issues/264)
-- Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/pSpitzner/beets-flask/issues/258)
-- Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/pSpitzner/beets-flask/issues/282)
+- Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/metasauce/beets-flask/issues/264)
+- Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/metasauce/beets-flask/issues/258)
+- Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/metasauce/beets-flask/issues/282)
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
-- Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
-- Fixed an issue with timestamps shown in the library view [#289](https://github.com/pSpitzner/beets-flask/issues/289)
+- Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/metasauce/beets-flask/pull/305)
+- Fixed an issue with timestamps shown in the library view [#289](https://github.com/metasauce/beets-flask/issues/289)
 
 ### Other (dev)
 
@@ -55,22 +54,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duration component could display nothing in some edge cases.
 - Action buttons now have a slight box shadow and are a bit more visible.
 - We now support playing container types [m4a, mp4, mov, alac, aac, mp3] that require seeking. This should fix issues with some mp4/m4a files not playing.
-- If no candidates are found during an import, we now show a message instead of an empty screen. [#190](https://github.com/pSpitzner/beets-flask/issues/190)
-- Archive files can now be deleted [#217](https://github.com/pSpitzner/beets-flask/issues/217)
-- Import Bootleg Button now works as expected [#218](https://github.com/pSpitzner/beets-flask/issues/218)
-- Startup script was not executed correctly if placed in `/config/beets-flask/startup.sh` [#227](https://github.com/pSpitzner/beets-flask/pull/227)
-- Another state-related bug around Searching for Candidates [#225](https://github.com/pSpitzner/beets-flask/issues/225). We now no longer require a certaint type of state before allowing to add candidates.
+- If no candidates are found during an import, we now show a message instead of an empty screen. [#190](https://github.com/metasauce/beets-flask/issues/190)
+- Archive files can now be deleted [#217](https://github.com/metasauce/beets-flask/issues/217)
+- Import Bootleg Button now works as expected [#218](https://github.com/metasauce/beets-flask/issues/218)
+- Startup script was not executed correctly if placed in `/config/beets-flask/startup.sh` [#227](https://github.com/metasauce/beets-flask/pull/227)
+- Another state-related bug around Searching for Candidates [#225](https://github.com/metasauce/beets-flask/issues/225). We now no longer require a certaint type of state before allowing to add candidates.
 - Asis candidates have been restyled to be more consistent with other candidate types. They now also include a cover art preview if available.
-- Fixed a typo in our opiniated beets config [#235](https://github.com/pSpitzner/beets-flask/issues/235)
+- Fixed a typo in our opiniated beets config [#235](https://github.com/metasauce/beets-flask/issues/235)
 - Fixed a styling issue in the artists list view which caused an overflow
 - Fixed a styling issue where an extra cancel-button (cross) was shown on webkit browsers
 
 ### Added
 
-- Added ability to define more groups to take care of ACLs, so that our non-root user can delete files on host systems, if desired. New environment variable `EXTRA_GROUPS` [#234](https://github.com/pSpitzner/beets-flask/issues/234)
-- The inbox info button now has a description of all actions [#145](https://github.com/pSpitzner/beets-flask/issues/145)
-- Subpage for version information and configs. You can access it via the version number in the navbar. [#205](https://github.com/pSpitzner/beets-flask/issues/205)
-- New config option `gui.inbox.debounce_before_autotag` to configure how many seconds to wait after the last filesystem event before starting autotagging. Same debounce applies to all inboxes. [#222](https://github.com/pSpitzner/beets-flask/issues/222)
+- Added ability to define more groups to take care of ACLs, so that our non-root user can delete files on host systems, if desired. New environment variable `EXTRA_GROUPS` [#234](https://github.com/metasauce/beets-flask/issues/234)
+- The inbox info button now has a description of all actions [#145](https://github.com/metasauce/beets-flask/issues/145)
+- Subpage for version information and configs. You can access it via the version number in the navbar. [#205](https://github.com/metasauce/beets-flask/issues/205)
+- New config option `gui.inbox.debounce_before_autotag` to configure how many seconds to wait after the last filesystem event before starting autotagging. Same debounce applies to all inboxes. [#222](https://github.com/metasauce/beets-flask/issues/222)
 - The library view on mobile now has a button to collapse the overview (above the tabs). This allows for more space when browsing the library on small screens.
 
 ### Other (dev)
@@ -100,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolved an issue in Vite development server where pythonTypes.ts would fail to load on first start due to inconsistent indentation (tabs vs spaces). This only affected the dev environment.
 - Development Docker container now runs as the `beetle` user instead of root, improving parity with the production environment.
-- Trailing slashes in configured inbox paths no longer cause crashes. [#182](https://github.com/pSpitzner/beets-flask/issues/182)
+- Trailing slashes in configured inbox paths no longer cause crashes. [#182](https://github.com/metasauce/beets-flask/issues/182)
 - The container now sets the `EDITOR` environment variable to `vi` so that `beet edit` and `beet config -e` work out of the box.
 
 ### Dependencies
@@ -112,14 +111,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Updated refresh_config to scan all modules for config references and overwrite them as needed to ensure consistency [#188](https://github.com/pSpitzner/beets-flask/issues/188)
+- Updated refresh_config to scan all modules for config references and overwrite them as needed to ensure consistency [#188](https://github.com/metasauce/beets-flask/issues/188)
 
 ## [1.1.1] - 25-08-15
 
 ### Fixed
 
-- Session cache wasn't invalidated on all folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/pSpitzner/beets-flask/issues/163)
-- We now use the beets `ignore` config option to ignore files and folders in the inbox view. This allows you to ignore files like `*.tmp`, `*.log`, etc. We also allow users to define the `gui.inbox.ignore` option to customize the ignored file patterns. [#176](https://github.com/pSpitzner/beets-flask/issues/176)
+- Session cache wasn't invalidated on all folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/metasauce/beets-flask/issues/163)
+- We now use the beets `ignore` config option to ignore files and folders in the inbox view. This allows you to ignore files like `*.tmp`, `*.log`, etc. We also allow users to define the `gui.inbox.ignore` option to customize the ignored file patterns. [#176](https://github.com/metasauce/beets-flask/issues/176)
 - Scrollbar for beets instructions wasn't visible on small screens.
 
 ### Other (dev)
@@ -144,14 +143,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed search results not showing [#161](https://github.com/pSpitzner/beets-flask/issues/161))
-- Fixed search box not clickable on small screens [#162](https://github.com/pSpitzner/beets-flask/issues/162)
+- Fixed search results not showing [#161](https://github.com/metasauce/beets-flask/issues/161))
+- Fixed search box not clickable on small screens [#162](https://github.com/metasauce/beets-flask/issues/162)
 
 ## [1.0.2] - 25-07-21
 
 ### Fixed
 
-- Artists separators were not regex escaped correctly, leading to issues with artists containing special characters. Additionally an empty list of separators was not handled correctly. [#159](https://github.com/pSpitzner/beets-flask/issues/159)
+- Artists separators were not regex escaped correctly, leading to issues with artists containing special characters. Additionally an empty list of separators was not handled correctly. [#159](https://github.com/metasauce/beets-flask/issues/159)
 
 ## [1.0.1] - 25-07-17
 
@@ -168,10 +167,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For bootlegs, display of track changes after import no longer broken
 - Navigating from inbox into folder details no longer toggles selection.
 - Padding issue where navbar could block content on mobile.
-- Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/pSpitzner/beets-flask/issues/138)
-- In albums and items view the clicking on artists does not return any results if the contained a separator character (e.g. `&`) [#132](https://github.com/pSpitzner/beets-flask/issues/138)
-- Cleanup old actions.tsx file, which included old unused code [#134](https://github.com/pSpitzner/beets-flask/issues/134)
-- The `cli_exit` event is now triggered after the import task is finished. This adds compatibility with some plugins which expected this event to be triggered after the import task is done. [#154](https://github.com/pSpitzner/beets-flask/issues/154).
+- Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/metasauce/beets-flask/issues/138)
+- In albums and items view the clicking on artists does not return any results if the contained a separator character (e.g. `&`) [#132](https://github.com/metasauce/beets-flask/issues/138)
+- Cleanup old actions.tsx file, which included old unused code [#134](https://github.com/metasauce/beets-flask/issues/134)
+- The `cli_exit` event is now triggered after the import task is finished. This adds compatibility with some plugins which expected this event to be triggered after the import task is done. [#154](https://github.com/metasauce/beets-flask/issues/154).
 
 ### Changed
 
@@ -233,7 +232,7 @@ Small version bump with fixes before jumping to 1.0.0.
 ### Added
 
 - Logo and favicon
-- Image now on docker hub: `pspitzner/beets-flask:stable`
+- Image now on docker hub: `metasauce/beets-flask:stable`
 - Auto-import: automatically import folders that are added to the inbox if the match is good enough.
   After a preview, import will start if the match quality is above the configured.
   Enable via the config.yaml, set the `autotag` field of a configred inbox folders to `"auto"`.
@@ -287,17 +286,17 @@ Small version bump with fixes before jumping to 1.0.0.
 
 - initial commit
 
-[Unreleased]: https://github.com/pSpitzner/beets-flask/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/pSpitzner/beets-flask/compare/v1.1.3...v1.2.0
-[1.1.3]: https://github.com/pSpitzner/beets-flask/compare/v1.1.2...v1.1.3
-[1.1.2]: https://github.com/pSpitzner/beets-flask/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/pSpitzner/beets-flask/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/pSpitzner/beets-flask/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/pSpitzner/beets-flask/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/pSpitzner/beets-flask/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/pSpitzner/beets-flask/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/pSpitzner/beets-flask/compare/v0.1.0...v1.0.0
-[0.1.0]: https://github.com/pSpitzner/beets-flask/compare/v0.0.4...v0.1.0
-[0.0.4]: https://github.com/pSpitzner/beets-flask/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/pSpitzner/beets-flask/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/pSpitzner/beets-flask/compare/v0.0.1...v0.0.2
+[Unreleased]: https://github.com/metasauce/beets-flask/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/metasauce/beets-flask/compare/v1.1.3...v1.2.0
+[1.1.3]: https://github.com/metasauce/beets-flask/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/metasauce/beets-flask/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/metasauce/beets-flask/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/metasauce/beets-flask/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/metasauce/beets-flask/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/metasauce/beets-flask/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/metasauce/beets-flask/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/metasauce/beets-flask/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/metasauce/beets-flask/compare/v0.0.4...v0.1.0
+[0.0.4]: https://github.com/metasauce/beets-flask/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/metasauce/beets-flask/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/metasauce/beets-flask/compare/v0.0.1...v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes ⚠️
 
+- **Repository moved**: The repository has moved from `pSpitzner/beets-flask` to `metasauce/beets-flask`. Please update your remotes and bookmarks accordingly.
 - **Base image changed**: The container base image is now `python:3.12-slim` (previously `python:3.11-alpine`). If you use a custom `startup.sh`, please verify compatibility, as Alpine-specific tooling and shell behavior may differ [#212](https://github.com/metasauce/beets-flask/issues/212)
 - **Upgraded `beets` from `v2.5.1` to `v2.12.0`**
   - This contains many changes and improvements, including some plugins.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ services:
             - /music_path/clean/:/music_path/clean/
 ```
 
+> [!NOTE]
+> We moved the repo and docker images to an organization account with v2.
+> Please update your docker setup to use `metasauce/beets-flask` instead of `pspitzner/beets-flask` to receive future udpates.
+
 This will create a container with the following folder structure:
 
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -d -p 5001:5001 \
 ```yaml
 services:
     beets-flask:
-        image: pspitzner/beets-flask:stable
+        image: metasauce/beets-flask:stable
         restart: unless-stopped
         ports:
             - "5001:5001"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     <h1 align="center">Beets-flask</h1>
 </p>
 
-[![version number](https://img.shields.io/github/package-json/v/pspitzner/beets-flask/main?filename=frontend%2Fpackage.json&label=version&color=blue)](https://github.com/pSpitzner/beets-flask/blob/main/CHANGELOG.md)
-[![Docker Pulls](https://img.shields.io/docker/pulls/pspitzner/beets-flask)](https://hub.docker.com/r/pspitzner/beets-flask/tags)
+[![version number](https://img.shields.io/github/package-json/v/metasauce/beets-flask/main?filename=frontend%2Fpackage.json&label=version&color=blue)](https://github.com/metasauce/beets-flask/blob/main/CHANGELOG.md)
+[![Docker Pulls](https://img.shields.io/docker/pulls/metasauce/beets-flask)](https://hub.docker.com/r/metasauce/beets-flask/tags)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?label=license)](https://opensource.org/licenses/MIT)
-[![docker-hub build status](https://img.shields.io/github/actions/workflow/status/pSpitzner/beets-flask/docker_hub.yml?label=docker%20build)](https://github.com/pSpitzner/beets-flask/pkgs/container/beets-flask)
+[![docker-hub build status](https://img.shields.io/github/actions/workflow/status/metasauce/beets-flask/docker_hub.yml?label=docker%20build)](https://github.com/metasauce/beets-flask/pkgs/container/beets-flask)
 [![Documentation Status](https://readthedocs.org/projects/beets-flask/badge/?version=latest)](https://beets-flask.readthedocs.io/en/latest/?badge=latest)
 
 <p align="center">
@@ -19,14 +19,14 @@
 
 <!-- start features -->
 
--   Autogenerate previews before importing
--   Auto-Import good matches
--   Import via GUI
--   Undo imports
--   Web-Terminal
--   Monitor multiple inboxes
--   Drag-and-drop files to upload into inboxes
--   Library view and search
+- Autogenerate previews before importing
+- Auto-Import good matches
+- Import via GUI
+- Undo imports
+- Web-Terminal
+- Monitor multiple inboxes
+- Drag-and-drop files to upload into inboxes
+- Library view and search
 
 <!-- end features -->
 
@@ -48,7 +48,6 @@ This is the main idea with beets-flask: For all folders in your inbox, we genera
 
 We provide a docker image with the full beeets-flask setup. You can run it with docker-compose or docker. We recommend using the `stable` tag, alternatively you may use `latest` for the most recent build.
 
-
 ### Setup container
 
 **Using docker**
@@ -64,7 +63,7 @@ docker run -d -p 5001:5001 \
     -v /music_path/inbox/:/music_path/inbox/ \
     -v /music_path/clean/:/music_path/clean/ \
     --name beets-flask \
-    pspitzner/beets-flask:stable
+    metasauce/beets-flask:stable
 ```
 
 <!-- end setup container -->

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -234,7 +234,7 @@ def is_archive_file(path: Path | str) -> bool:
     """Check if a file is an archive file based on its extension.
 
     It seems like there is a memory issue with `tarfile.is_tarfile`
-    (see https://github.com/pSpitzner/beets-flask/issues/258). We try
+    (see https://github.com/metasauce/beets-flask/issues/258). We try
     to avoid this by only checking the file extension here, and not trying to open the file.
     """
     allowed_extensions = allowed_archive_extensions()

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
     beets-flask:
-        image: pspitzner/beets-flask:stable
+        image: metasauce/beets-flask:stable
         restart: unless-stopped
         ports:
             - "5001:5001"

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -12,11 +12,11 @@ build:
     python: "3.12"
   jobs:
     create_environment:
+      # Note: each command might run in a separate shell
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - cd backend
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --project backend --all-extras --group docs
     install:
       - "true"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,11 +63,11 @@ html_theme_options = {
         "color-brand-content": "#dee2e6",
     },
     # Sources for editing
-    "source_view_link": "https://github.com/pspitzner/beets-flask/blob/main/docs/{filename}",
+    "source_view_link": "https://github.com/metasauce/beets-flask/blob/main/docs/{filename}",
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/pspitzner/beets-flask",
+            "url": "https://github.com/metasauce/beets-flask",
             "html": """
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
             """,

--- a/docs/develop/contribution.md
+++ b/docs/develop/contribution.md
@@ -6,19 +6,19 @@ We are always happy to see new contributors! If small or large, every contributi
 
 Some technical knowledge for the following tools is required to get started with the project. If you are not familiar with them, please check out the documentation for each tool and make sure you have them installed.
 
--   [Docker](https://docs.docker.com/get-started/)
--   [Docker Compose](https://docs.docker.com/compose/)
--   [Python](https://www.python.org/downloads/) 3.10 or higher
--   [Node.js](https://nodejs.org/en/download/) 18 or higher
--   [git](https://git-scm.com/downloads)
--   [pnpm](https://pnpm.io/installation) (or any other package manager)
+- [Docker](https://docs.docker.com/get-started/)
+- [Docker Compose](https://docs.docker.com/compose/)
+- [Python](https://www.python.org/downloads/) 3.10 or higher
+- [Node.js](https://nodejs.org/en/download/) 18 or higher
+- [git](https://git-scm.com/downloads)
+- [pnpm](https://pnpm.io/installation) (or any other package manager)
 
 ## Setting Up the Development Environment
 
 1. **Clone the repository:**
 
 ```bash
-git clone https://github.com/pSpitzner/beets-flask
+git clone https://github.com/metasauce/beets-flask
 cd beets-flask
 ```
 
@@ -93,7 +93,7 @@ Fork the repository and create a new branch for your changes. Feel free to follo
 ## Example docker compose
 
 ```bash
-git clone https://github.com/pSpitzner/beets-flask.git ./beets_flask_dev
+git clone https://github.com/metasauce/beets-flask.git ./beets_flask_dev
 cd ./beets_flask_dev
 mkdir local
 ```

--- a/docs/develop/resources/docker.md
+++ b/docs/develop/resources/docker.md
@@ -1,10 +1,10 @@
 # Docker
 
-We use docker for containerization and deployment of our application. You can find the files needed to build the docker images in the [`docker`](https://github.com/pSpitzner/beets-flask/tree/main/docker) folder.
+We use docker for containerization and deployment of our application. You can find the files needed to build the docker images in the [`docker`](https://github.com/metasauce/beets-flask/tree/main/docker) folder.
 
 Redis-Caching seems to be very persistent and we have not figured out how to completely reset it without _rebuilding_ the container.
 Thus, currently, after code changes that run inside a redis worker `docker-compose up --build` is needed even when live-mounting the repo.
 
 ## Entrypoints
 
-We use different entrypoints for the different environments. You can find all scripts in the [`docker/entrypoints`](https://github.com/pSpitzner/beets-flask/tree/main/docker/entrypoints) folder.
+We use different entrypoints for the different environments. You can find all scripts in the [`docker/entrypoints`](https://github.com/metasauce/beets-flask/tree/main/docker/entrypoints) folder.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ cd beets-flask
 2. Download the `docker-compose.yaml` file or create it manually and copy the content from below.
 
 ```bash
-wget https://raw.githubusercontent.com/pspitzner/beets-flask/main/docker/docker-compose.yaml
+wget https://raw.githubusercontent.com/metasauce/beets-flask/main/docker/docker-compose.yaml
 ```
 
 If you want to create it manually, you can use the following content:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,8 +7,9 @@ We try to be feature-complete with respect to beets, but there are some limitati
 You might be tempted to import a large existing library (not previously tagged in beets) all at once by moving it into the inbox folder. Currently, once you hit some hundred folder or so, this will get laggy, due to some frontend-logic we have not optimized yet.
 
 Some possible workarounds have been discussed in the following issues:
-- [#164](https://github.com/pSpitzner/beets-flask/issues/164)
-- [#175](https://github.com/pSpitzner/beets-flask/issues/175)
+
+- [#164](https://github.com/metasauce/beets-flask/issues/164)
+- [#175](https://github.com/metasauce/beets-flask/issues/175)
 
 ## Singletons are not supported (wont fix)
 
@@ -19,7 +20,8 @@ While these exceptions (likely) meant acceptable extra effort when beets was ori
 The simple workaround is to place individual files in their own folder (or zip them).
 
 See also:
-- [#186](https://github.com/pSpitzner/beets-flask/issues/186#issuecomment-3201103451)
+
+- [#186](https://github.com/metasauce/beets-flask/issues/186#issuecomment-3201103451)
 
 ## Only the import option `copy` is supported
 
@@ -27,8 +29,8 @@ In order to provide an easy way to correct automatic imports that went wrong, it
 We are thinking about workarounds that add back the convenience of automatic deletion.
 
 See also:
-- [#193](https://github.com/pSpitzner/beets-flask/issues/193)
 
+- [#193](https://github.com/metasauce/beets-flask/issues/193)
 
 ## Upload via webfrontend only supports files
 

--- a/docs/plugins/supported-plugins.md
+++ b/docs/plugins/supported-plugins.md
@@ -1,9 +1,8 @@
 # Compatibility
 
-
 ```{tip}
 If a plugin works for you or doesn't, consider
-[opening an issue or a PR](https://github.com/pspitzner/beets-flask) to add it to the
+[opening an issue or a PR](https://github.com/metasauce/beets-flask) to add it to the
 compatible or incompatible list.
 ```
 
@@ -37,23 +36,22 @@ Enabled by default.
 
 Plugins confirmed to work. No dedicated UI integration, but function correctly.
 
-| Plugin | Description |
-|--------|-------------|
-| [fetchart](https://docs.beets.io/en/latest/plugins/fetchart.html) | Fetch album artwork from multiple sources |
-| [embedart](https://docs.beets.io/en/latest/plugins/embedart.html) | Embed fetched artwork into audio files |
-| [the](https://docs.beets.io/en/latest/plugins/the.html) | Move articles to end of names |
-| [ftintitle](https://docs.beets.io/en/latest/plugins/ftintitle.html) | Move featured artists to title |
-| [lastgenre](https://docs.beets.io/en/latest/plugins/lastgenre.html) | Fetch genres from Last.fm |
-| [albumtypes](https://docs.beets.io/en/latest/plugins/albumtypes.html) | Add album type info |
-| [scrub](https://docs.beets.io/en/latest/plugins/scrub.html) | Clean extraneous tags |
-| [zero](https://docs.beets.io/en/latest/plugins/zero.html) | Null fields to reduce clutter |
-| [convert](https://docs.beets.io/en/latest/plugins/convert.html) | Transcode audio files |
-| [fromfilename](https://docs.beets.io/en/latest/plugins/fromfilename.html) | Guess metadata from filename |
-| [inline](https://docs.beets.io/en/latest/plugins/inline.html) | Use Python snippets in templates |
-| [edit](https://docs.beets.io/en/latest/plugins/edit.html) | Edit metadata via external editor |
-| [discogs](https://docs.beets.io/en/latest/plugins/discogs.html) | Match against Discogs |
-| [keyfinder](https://docs.beets.io/en/latest/plugins/keyfinder.html) | Detect musical key (requires compilation) |
-
+| Plugin                                                                    | Description                               |
+| ------------------------------------------------------------------------- | ----------------------------------------- |
+| [fetchart](https://docs.beets.io/en/latest/plugins/fetchart.html)         | Fetch album artwork from multiple sources |
+| [embedart](https://docs.beets.io/en/latest/plugins/embedart.html)         | Embed fetched artwork into audio files    |
+| [the](https://docs.beets.io/en/latest/plugins/the.html)                   | Move articles to end of names             |
+| [ftintitle](https://docs.beets.io/en/latest/plugins/ftintitle.html)       | Move featured artists to title            |
+| [lastgenre](https://docs.beets.io/en/latest/plugins/lastgenre.html)       | Fetch genres from Last.fm                 |
+| [albumtypes](https://docs.beets.io/en/latest/plugins/albumtypes.html)     | Add album type info                       |
+| [scrub](https://docs.beets.io/en/latest/plugins/scrub.html)               | Clean extraneous tags                     |
+| [zero](https://docs.beets.io/en/latest/plugins/zero.html)                 | Null fields to reduce clutter             |
+| [convert](https://docs.beets.io/en/latest/plugins/convert.html)           | Transcode audio files                     |
+| [fromfilename](https://docs.beets.io/en/latest/plugins/fromfilename.html) | Guess metadata from filename              |
+| [inline](https://docs.beets.io/en/latest/plugins/inline.html)             | Use Python snippets in templates          |
+| [edit](https://docs.beets.io/en/latest/plugins/edit.html)                 | Edit metadata via external editor         |
+| [discogs](https://docs.beets.io/en/latest/plugins/discogs.html)           | Match against Discogs                     |
+| [keyfinder](https://docs.beets.io/en/latest/plugins/keyfinder.html)       | Detect musical key (requires compilation) |
 
 ## Incompatible
 

--- a/frontend/src/errors.tsx
+++ b/frontend/src/errors.tsx
@@ -207,7 +207,7 @@ export function GenericErrorCard({
                         sx={{ color: 'text.secondary', marginTop: '0.2rem' }}
                     >
                         If this is a reoccurring issue, feel free to raise an{' '}
-                        <Link href="https://github.com/pSpitzner/beets-flask/issues">
+                        <Link href="https://github.com/metasauce/beets-flask/issues">
                             issue on GitHub
                         </Link>
                         .

--- a/frontend/src/routes/_frontpage/index.tsx
+++ b/frontend/src/routes/_frontpage/index.tsx
@@ -211,7 +211,7 @@ function Footer() {
                 <Typography variant="caption">&nbsp;Documentation</Typography>
             </Link>
             <Link
-                href="https://github.com/pSpitzner/beets-flask"
+                href="https://github.com/metasauce/beets-flask"
                 target="_blank"
                 variant="body2"
             >
@@ -219,7 +219,7 @@ function Footer() {
                 <Typography variant="caption">&nbsp;GitHub</Typography>
             </Link>
             <Link
-                href="https://github.com/pSpitzner/beets-flask/issues/new"
+                href="https://github.com/metasauce/beets-flask/issues/new"
                 target="_blank"
                 variant="body2"
             >


### PR DESCRIPTION
This pull request updates the project to reflect its migration from the `pSpitzner/beets-flask` repository to `metasauce/beets-flask`. It changes all references, Docker images, documentation links, and issue tracker URLs to the new organization. The changes ensure that users and contributors are directed to the correct repository, Docker images, and support channels.