### PR TITLE
Auth extension: pluggable authentication providers for beets plugins via new `/auth` route

### DIFF
--- a/backend/alembic/versions/2026_09_10_1800-7b11d6a3c6a7_drop_task_cur_artist_and_album.py
+++ b/backend/alembic/versions/2026_09_10_1800-7b11d6a3c6a7_drop_task_cur_artist_and_album.py
@@ -1,0 +1,48 @@
+"""Drop task cur_artist and cur_album
+
+Since beets 2.14 the current artist and album are no longer stored on
+the task, but derived from its items via `ImportTask.source`:
+`Source.from_items` calls the same `get_most_common_tags` that beets <
+2.14 used to populate `cur_artist` / `cur_album`.
+
+The dropped values are a pure function of the task's items, which are
+persisted losslessly in `items` / `tasks_items` and restored together
+with the task, so nothing is backfilled: the source is recomputed on
+demand after loading.
+
+Revision ID: 7b11d6a3c6a7
+Revises: 25649aa3ba78
+Create Date: 2026-09-10 18:00:04.303442
+
+"""
+
+from __future__ import annotations
+
+
+import sqlalchemy as sa
+
+from alembic import op
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "7b11d6a3c6a7"
+down_revision: str | Sequence[str] | None = "25649aa3ba78"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("task") as batch_op:
+        batch_op.drop_column("cur_artist")
+        batch_op.drop_column("cur_album")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("task") as batch_op:
+        batch_op.add_column(sa.Column("cur_artist", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("cur_album", sa.String(), nullable=True))

--- a/backend/beets_flask/database/mapper/states.py
+++ b/backend/beets_flask/database/mapper/states.py
@@ -70,8 +70,6 @@ class TaskStateMapper(DBMapper[TaskState, TaskStateInDb]):
             ],
         )
         beets_task.choice_flag = model.choice_flag
-        beets_task.cur_artist = model.cur_artist
-        beets_task.cur_album = model.cur_album
         old_paths: list[bytes] | None = (
             pickle.loads(model.old_paths) if model.old_paths else None
         )
@@ -147,8 +145,6 @@ class TaskStateMapper(DBMapper[TaskState, TaskStateInDb]):
             chosen_candidate_id=obj.chosen_candidate_state_id,
             progress=obj.progress.progress,
             choice_flag=obj.task.choice_flag,
-            cur_artist=obj.task.cur_artist,
-            cur_album=obj.task.cur_album,
             old_paths=old_paths,
         )
         ctx.to_cache[id(obj)] = model

--- a/backend/beets_flask/database/models/states.py
+++ b/backend/beets_flask/database/models/states.py
@@ -410,12 +410,6 @@ class TaskStateInDb(Base):
     )
     choice_flag: Mapped[Action | None]
 
-    # To allow for continue we need to store the current artist and album
-    # TODO: REMOVE this is not needed!! We can look at the asis candidate for this!
-    # E.g. frontend component to compare two candidates
-    cur_artist: Mapped[str | None]
-    cur_album: Mapped[str | None]
-
     progress: Mapped[Progress]
 
     def __init__(
@@ -429,8 +423,6 @@ class TaskStateInDb(Base):
         chosen_candidate_id: str | None = None,
         progress: Progress = Progress.NOT_STARTED,
         choice_flag: Action | None = None,
-        cur_artist: str | None = None,
-        cur_album: str | None = None,
     ):
         super().__init__(id)
         self.toppath = toppath
@@ -442,8 +434,6 @@ class TaskStateInDb(Base):
         self.chosen_candidate_id = chosen_candidate_id
         self.progress = progress
         self.choice_flag = choice_flag
-        self.cur_artist = cur_artist
-        self.cur_album = cur_album
 
 
 class CandidateStateInDb(Base):

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -453,10 +453,8 @@ def _is_within_multi_dir(path: Path | str) -> bool:
     if isinstance(path, str):
         path = Path(path)
 
-    path_str = path.name  # Use pathlib to get the basename
-
     for marker_pat in MULTIDISC_PATTERNS:
-        match = marker_pat.match(path_str.encode("utf-8"))
+        match = marker_pat.match(path.name)
         if match:
             return True
     return False

--- a/backend/beets_flask/extensions/__init__.py
+++ b/backend/beets_flask/extensions/__init__.py
@@ -14,3 +14,13 @@ artwork resolution). The module defines an abstract base class describing the
 extension interface, while concrete implementations live in
 `extensions/providers/` (one module per provider).
 """
+
+from .art import ArtResult, ArtSource
+from .auth import AuthExtension, PkceData
+
+__all__ = [
+    "ArtResult",
+    "ArtSource",
+    "AuthExtension",
+    "PkceData",
+]

--- a/backend/beets_flask/extensions/auth.py
+++ b/backend/beets_flask/extensions/auth.py
@@ -1,0 +1,76 @@
+"""Auth extension: Provides generic authentication support for plugins that need it.
+
+Some plugins needs authentication to access their API or work at all, e.g. tidal needs
+you to run `beet tidal --auth`
+"""
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class PkceData:
+    """Sensitive PKCE flow state (RFC 7636).
+
+    The ``code_verifier`` is required to redeem the authorization code, and
+    ``state`` binds the redirect URL to the flow (CSRF). Together they make
+    the flow stateless across processes: they must be persisted server-side
+    between the two steps and must never reach the client.
+    """
+
+    code_verifier: str
+    state: str
+
+
+class AuthExtension:
+    """Interface for an authentication extension.
+
+    Provides a way to check for authentication and to perform authentication if needed.
+
+    Only the PKCE flow (see RFC 7636) is supported right now: the user authenticates in
+    their browser, and the resulting authorization code is exchanged for a token.
+    Extensions implement this as two steps:
+
+    1. :meth:`start_authentication` returns the sensitive :class:`PkceData`
+       plus the URL the user must visit.
+    2. After the user logs in, the service redirects back to a URL
+       containing an authorization code. The caller passes that redirect
+       URL (together with the flow state) to
+       :meth:`complete_authentication`, which exchanges the code for a
+       token and persists it.
+
+    The extension itself does not persist any state; the caller is
+    responsible for keeping the (sensitive) flow state server-side between
+    the two steps, e.g. in the app's storage backend.
+
+    Other flows (e.g. client credentials) may be added later if a plugin
+    requires them.
+    """
+
+    name: ClassVar[str]
+
+    @classmethod
+    @abstractmethod
+    def is_enabled(cls) -> bool:
+        """Return whether the provider is available (e.g. its plugin is enabled)."""
+
+    @abstractmethod
+    def is_authenticated(self) -> bool:
+        """Return whether the user is authenticated."""
+
+    @abstractmethod
+    def start_authentication(self) -> tuple[PkceData, str]:
+        """Start the PKCE flow.
+
+        Returns the sensitive :class:`PkceData` and the URL the user must
+        visit.
+        """
+
+    @abstractmethod
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        """Complete the flow using the state from ``start_authentication``.
+
+        The ``redirect_url`` contains the authorization code, which is
+        exchanged for a token.
+        """

--- a/backend/beets_flask/extensions/providers/__init__.py
+++ b/backend/beets_flask/extensions/providers/__init__.py
@@ -1,7 +1,7 @@
-"""Concrete art providers.
+"""Concrete providers.
 
-Each module implements one `ArtSource`. This package holds the
-hard-coded list of sources; a registry may replace this later.
+Each module implements one `ArtSource` and/or `AuthExtension`. This package
+holds the hard-coded list of sources; a registry may replace this later.
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .file import FileArtSource
 from .musicbrainz import MusicbrainzArtSource
 from .spotify import SpotifyArtSource
+from .tidal import TidalAuth
 
 # TODO: We should add a proper registry here to simplify this
 # Not needed for now but once we add more parts to the extension system
@@ -20,6 +21,12 @@ ART_SOURCES = [
     MusicbrainzArtSource(),
 ]
 
+
+AUTH_EXTENSIONS = [
+    TidalAuth(),
+]
+
 __all__ = [
     "ART_SOURCES",
+    "AUTH_EXTENSIONS",
 ]

--- a/backend/beets_flask/extensions/providers/tidal.py
+++ b/backend/beets_flask/extensions/providers/tidal.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from functools import cache
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from beets import plugins as beets_plugins
+from beets.exceptions import UserError
+
+from beets_flask.logger import log
+
+from .. import AuthExtension, PkceData
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession
+    from beetsplug.tidal import TidalPlugin
+
+
+class TidalAuth(AuthExtension):
+    """Authenticate with Tidal.
+
+    Implements the same auth flow as in beets' Tidal plugin, using the
+    `requests-oauthlib` session to generate the auth URL and exchange the code for a
+    token.
+    """
+
+    name: ClassVar[str] = "tidal"
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        return cls.tidal_plugin() is not None
+
+    @classmethod
+    @cache
+    def tidal_plugin(cls) -> TidalPlugin | None:
+        """Return beets' loaded Tidal plugin, if enabled."""
+        try:
+            from beetsplug.tidal import TidalPlugin as _TidalPlugin
+        except ImportError as err:
+            log.debug("Tidal plugin is unavailable: %s", err)
+            return None
+
+        return next(
+            (
+                plugin
+                for plugin in beets_plugins.find_plugins()
+                if isinstance(plugin, _TidalPlugin)
+            ),
+            None,
+        )
+
+    def is_authenticated(self) -> bool:
+        """Check if the user is authenticated with Tidal."""
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            return False
+
+        # Raises UserError if not authenticated. ``require_authentication`` is a
+        # beets ``import_begin`` listener and thus expects an ``ImportSession``,
+        # but the check does not use it and no session exists in this context.
+        try:
+            plugin.require_authentication(cast("ImportSession", None))
+        except UserError:
+            return False
+
+        return True
+
+    def start_authentication(self) -> tuple[PkceData, str]:
+        """Start the PKCE flow: build the login URL and return the flow state.
+
+        The PKCE verifier and CSRF state live on the OAuth session object,
+        which is process-local, so they are returned here as sensitive
+        :class:`PkceData`. The caller is responsible for persisting them
+        server-side until the flow is completed.
+        """
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            raise RuntimeError("The Tidal plugin is not enabled.")
+
+        session = plugin.api.session
+        auth_url, state = session.authorization_url("https://login.tidal.com/authorize")
+        pkce = PkceData(code_verifier=session._code_verifier, state=state)
+        return pkce, auth_url
+
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        """Exchange the auth code from ``redirect_url`` for a token and save it.
+
+        The PKCE state from ``pkce`` is restored on the OAuth session before
+        the exchange, so it can run on any worker.
+        """
+
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            raise RuntimeError("The Tidal plugin is not enabled.")
+
+        session = plugin.api.session
+        session._state = pkce.state
+        session._code_verifier = pkce.code_verifier
+        session.fetch_token(
+            "https://auth.tidal.com/v1/oauth2/token",
+            authorization_response=redirect_url,
+            include_client_id=True,
+        )
+        session.save_token(session.token)

--- a/backend/beets_flask/importer/pipeline.py
+++ b/backend/beets_flask/importer/pipeline.py
@@ -74,7 +74,7 @@ class AsyncPipeline[Task: Any, R]:
             await _next_resolve_async(stage)
 
         async for task in self.start_tasks:
-            msgs: list[Task] = _allmsgs(task)  # returns a list of tasks
+            msgs: list[Task] = _allmsgs(task)  # type: ignore[assignment]  # returns a list of tasks
 
             for stage in self.stages:
                 next_coros: list[Coroutine] = [

--- a/backend/beets_flask/importer/session.py
+++ b/backend/beets_flask/importer/session.py
@@ -570,19 +570,19 @@ class AddCandidatesSession(PreviewSession):
 
         log.debug(f"Using {search=} for {task_state.id=}, {task_state.paths=}")
 
-        _, _, prop = autotag.tag_album(
-            task.items,
+        proposal = autotag.tag_album(
+            task.source,
             search_ids=search["search_ids"],
             search_name=search["search_name"],
             search_artist=search["search_artist"],
         )
 
-        task_state.add_candidates(prop.candidates)
+        task_state.add_candidates(proposal.candidates)
 
         # Update quality of best candidate, likely not needed for us, only beets cli.
-        task.rec = max(prop.recommendation, task.rec or autotag.Recommendation.none)
+        task.rec = max(proposal.recommendation, task.rec or autotag.Recommendation.none)
 
-        if len(prop.candidates) == 0:
+        if len(proposal.candidates) == 0:
             error_text = "Search found no candidates via "
             if search["search_ids"]:
                 error_text += f"ids: {', '.join(search['search_ids'])}; "

--- a/backend/beets_flask/importer/stages.py
+++ b/backend/beets_flask/importer/stages.py
@@ -414,19 +414,16 @@ def lookup_candidates(
     session: BaseSession,
     task: ImportTask,
 ):
-    """Performing the initial MusicBrainz lookup for an album.
+    """Performing the initial lookup for an album.
 
-    We tweaks this from upstream beets to not
-    call `task.lookup_candidates()` but instead `session.lookup_candidates(task)`,
-    with some extra logic
+    We tweaks this from upstream beets to not call `task.lookup_candidates()` but
+    instead `session.lookup_candidates(task)` with some extra logic.
 
-    This is more consistent, as it allows the logic
-    to be modified by each kind of session.
+    This is more convinient, as it allows us to modify logic the logic by each kind
+    of session.
 
-    Calls `task.lookup_candidates()`,
+    `session.lookup_candidates` calls `task.lookup_candidates`,
     which sets attributes of the task:
-        - cur_artist   # metadata in file
-        - cur_album
         - candidates
         - rec
     """

--- a/backend/beets_flask/importer/states.py
+++ b/backend/beets_flask/importer/states.py
@@ -6,7 +6,7 @@ from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast
 from uuid import uuid4 as uuid
 
 from beets import importer
@@ -386,9 +386,9 @@ class TaskState(BaseState):
         """Current metadata of the task.
 
         This is the metadata of the music files on disk.
-        (In a beets context, cur_artist and cur_album)
+        TODO: We should migrate to use likelies directly since it is typed now.
         """
-        likelies, _ = get_most_common_tags(self.items)
+        likelies = get_most_common_tags(self.items)
         return Metadata(**{k: str(v) for k, v in likelies.items()})  # type: ignore[typeddict-item]
 
     # ---------------------------------------------------------------------------- #
@@ -485,10 +485,9 @@ class CandidateState(BaseState):
         items: list[BeetsItem] = task_state.task.items
 
         # FIXME: we do this lookup twice, once here and once in current_metadata
+        info: dict[str, Any] = {}
         if len(items) > 0:
-            info, _ = get_most_common_tags(items)
-        else:
-            info = {}
+            info = get_most_common_tags(items)
         info["data_source"] = "asis"
         info["data_url"] = f"file://{task_state.toppath}"
 

--- a/backend/beets_flask/importer/states.py
+++ b/backend/beets_flask/importer/states.py
@@ -403,8 +403,8 @@ class TaskState(BaseState):
             candidates=[c.serialize() for c in self.candidate_states],
             asis_candidate=self.asis_candidate.serialize(),
             current_metadata=self.current_metadata,
-            # TODO: maybe we can merge current_metadata (which is cur_artist/album in
-            # old beets) into the asis_candidate
+            # TODO: maybe we can merge current_metadata (which is derived from
+            # `task.source`) into the asis_candidate
             chosen_candidate_id=self.chosen_candidate_state_id,
             duplicate_action=self.duplicate_action,
             completed=self.completed,
@@ -546,22 +546,6 @@ class CandidateState(BaseState):
         return candidate
 
     # --------------------- Helper to lift / unnset from match to -------------------- #
-    @property
-    def cur_artist(self) -> str:
-        """Current artist, usually the meta data of the music files.
-
-        Named to be consistent with beets.
-        """
-        return str(self.task_state.task.cur_artist)
-
-    @property
-    def cur_album(self) -> str:
-        """Current album, usually the meta data of the music files.
-
-        Named to be consistent with beets.
-        """
-        return str(self.task_state.task.cur_album)
-
     @property
     def artist(self) -> str | None:
         """Artist of the match."""

--- a/backend/beets_flask/importer/states.py
+++ b/backend/beets_flask/importer/states.py
@@ -691,7 +691,8 @@ class CandidateState(BaseState):
                 duplicates.append(album)
 
         # Write duplicates information!
-        self.duplicate_ids = [d.id for d in duplicates]
+        # TODO: Me should migrate duplicate ids from str to int
+        self.duplicate_ids = [str(d.id) for d in duplicates if d.id is not None]
 
         return duplicates
 

--- a/backend/beets_flask/importer/states.py
+++ b/backend/beets_flask/importer/states.py
@@ -11,7 +11,6 @@ from uuid import uuid4 as uuid
 
 from beets import importer
 from beets.ui import _open_library
-from beets.ui.commands.import_.display import show_change
 from beets.util import bytestring_path, get_most_common_tags
 from deprecated import deprecated
 
@@ -22,7 +21,6 @@ from beets_flask.importer.progress import (
     ProgressState,
     SerializedProgressState,
 )
-from beets_flask.utility import capture_stdout_stderr
 
 from .types import (
     AlbumInfo,
@@ -475,20 +473,6 @@ class CandidateState(BaseState):
             return "track"
         else:
             raise ValueError("Unknown type")
-
-    @property
-    def diff_preview(self) -> str:
-        """Diff preview of the match to the current meta data."""
-        out, err, _ = capture_stdout_stderr(
-            show_change,
-            self.task_state.task.cur_artist,
-            self.task_state.task.cur_album,
-            self.match,
-        )
-        res = out.lstrip("\n")
-        if len(err) > 0:
-            res += f"\n\nError: {err}"
-        return res
 
     @classmethod
     def asis_candidate(cls, task_state: TaskState) -> CandidateState:

--- a/backend/beets_flask/redis.py
+++ b/backend/beets_flask/redis.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import secrets
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import redis
 from rq import Queue
@@ -24,6 +26,37 @@ import_queue = Queue("import", connection=redis_conn, default_timeout=600)
 
 
 queues = [preview_queue, import_queue]
+
+
+_KEY_PREFIX = "store:"
+
+
+def store(value: Any, ttl: int = 600) -> str:
+    """Store a JSON-serializable value and return an opaque id (with a TTL).
+
+    The value expires after ``ttl`` seconds. The returned id is what the
+    caller hands to :func:`consume` to retrieve (and delete) the value.
+    """
+    object_id = secrets.token_urlsafe(32)
+    redis_conn.set(
+        f"{_KEY_PREFIX}{object_id}",
+        json.dumps(value),
+        ex=ttl,
+    )
+    return object_id
+
+
+def consume(object_id: str) -> Any | None:
+    """Retrieve and delete a stored value by id (single-use).
+
+    Returns the stored value, or None if the id is unknown or has expired.
+    """
+    key = f"{_KEY_PREFIX}{object_id}"
+    raw = redis_conn.get(key)
+    if raw is None:
+        return None
+    redis_conn.delete(key)
+    return json.loads(raw)
 
 
 async def wait_for_job_results(
@@ -72,9 +105,11 @@ async def wait_for_job_results(
 
 
 __all__ = [
+    "consume",
     "import_queue",
     "preview_queue",
     "queues",
     "redis_conn",
+    "store",
     "wait_for_job_results",
 ]

--- a/backend/beets_flask/server/exceptions.py
+++ b/backend/beets_flask/server/exceptions.py
@@ -197,7 +197,7 @@ def exception_as_return_value[**P, R](
             return await f(*args, **kwargs)
         # Some exceptions are not serializable, so we need to convert them to a
         # serialized format. E.g. OSErrors
-        except ApiError as e:
+        except (ApiError, UserError) as e:
             log.info(e)
             return to_serialized_exception(e)
         except Exception as e:

--- a/backend/beets_flask/server/routes/__init__.py
+++ b/backend/beets_flask/server/routes/__init__.py
@@ -1,6 +1,7 @@
 from quart import Blueprint, Quart
 
 from .art_preview import art_blueprint
+from .auth import auth_bp
 from .config import config_bp
 from .db_models import register_state_models
 from .exception import error_bp
@@ -14,6 +15,7 @@ backend_bp = Blueprint("backend", __name__, url_prefix="/api_v1")
 
 # Register all backend blueprints
 backend_bp.register_blueprint(art_blueprint)
+backend_bp.register_blueprint(auth_bp)
 backend_bp.register_blueprint(config_bp)
 backend_bp.register_blueprint(error_bp)
 backend_bp.register_blueprint(file_upload_bp)

--- a/backend/beets_flask/server/routes/auth.py
+++ b/backend/beets_flask/server/routes/auth.py
@@ -1,0 +1,110 @@
+"""Auth endpoints for the frontend.
+
+Exposes the registered auth extensions (see `beets_flask.extensions.providers`)
+to the frontend: checking which providers are available and running the PKCE
+authentication flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TypedDict
+
+from quart import Blueprint, jsonify, request
+
+from beets_flask.extensions.auth import AuthExtension, PkceData
+from beets_flask.extensions.providers import AUTH_EXTENSIONS
+from beets_flask.redis import consume, store
+from beets_flask.server.exceptions import InvalidUsageError
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+class AuthProviderStatus(TypedDict):
+    name: str
+    authenticated: bool
+
+
+@auth_bp.route("/providers", methods=["GET"])
+async def get_providers() -> list[AuthProviderStatus]:
+    """List all registered auth providers with their authentication status."""
+    providers: list[AuthProviderStatus] = [
+        {
+            "name": ext.name,
+            "authenticated": ext.is_authenticated(),
+        }
+        for ext in _get_auth_extensions()
+    ]
+    return providers
+
+
+class AuthFlow(TypedDict):
+    """In-progress PKCE flow handed to the client (see ``AuthExtension``)."""
+
+    url: str
+    flow_id: str
+
+
+@auth_bp.route("/<name>/url", methods=["GET"])
+async def get_authentication_url(name: str) -> AuthFlow:
+    """Start the PKCE flow for ``name``.
+
+    Returns the URL the user must visit together with an opaque ``flow_id``
+    that must be passed back to the ``complete`` endpoint. The sensitive
+    flow state stays in the server-side store.
+    """
+    ext = _get_auth_extension(name)
+    try:
+        pkce, url = ext.start_authentication()
+    except RuntimeError as err:
+        raise InvalidUsageError(str(err)) from err
+    flow_id = store(asdict(pkce))
+    return {"url": url, "flow_id": flow_id}
+
+
+@auth_bp.route("/<name>/complete", methods=["POST"])
+async def complete_authentication(name: str):
+    """Complete the PKCE flow for ``name`` using the redirect URL.
+
+    The request body must contain the ``flow_id`` returned by the ``url`` endpoint and
+    the ``redirect_url``.
+    """
+    ext = _get_auth_extension(name)
+    params = await request.get_json()
+    redirect_url = params.pop("redirect_url", None)
+    flow_id = params.pop("flow_id", None)
+
+    if not redirect_url or not flow_id:
+        raise InvalidUsageError(
+            "Missing required parameters 'redirect_url' and 'flow_id' must be provided."
+        )
+
+    flow_state = consume(flow_id)
+    if flow_state is None:
+        raise InvalidUsageError(
+            "Auth flow not found or expired. Please start a new flow."
+        )
+
+    try:
+        pkce = PkceData(**flow_state)
+    except TypeError as err:
+        raise InvalidUsageError(f"Invalid stored flow data: {err}") from err
+
+    try:
+        ext.complete_authentication(pkce, redirect_url)
+    except RuntimeError as err:
+        raise InvalidUsageError(str(err)) from err
+    return jsonify({"authenticated": True})
+
+
+def _get_auth_extensions() -> list[AuthExtension]:
+    """Return the enabled auth extensions from the registry."""
+    return [ext for ext in AUTH_EXTENSIONS if ext.is_enabled()]
+
+
+def _get_auth_extension(name: str) -> AuthExtension:
+    """Return the auth extension with the given name, or raise an exception."""
+    for ext in _get_auth_extensions():
+        if ext.name == name:
+            return ext
+    raise InvalidUsageError(f"No auth provider found with name '{name}'.")

--- a/backend/beets_flask/utility.py
+++ b/backend/beets_flask/utility.py
@@ -1,49 +1,4 @@
-import io
-import sys
-
-from deprecated import deprecated
-
 from .logger import log
-
-# ------------------------------------------------------------------------------------ #
-#                                        Logging                                       #
-# ------------------------------------------------------------------------------------ #
-
-
-@deprecated
-def capture_stdout_stderr(func, *args, **kwargs):
-    """Capture the output of a function that uses beets' custom `print_`.
-
-    beets.ui uses a custom `print_` function to display most console output
-    in a nicely formatted way. This is the easiest way to capture that output.
-
-    Args:
-        func (callable): function to call
-        *args: positional arguments to pass to `func`
-        **kwargs: keyword arguments to pass to `func`
-
-    Returns:
-    -------
-        tuple: (str, str, any) -- stdout, stderr, return value of `func`
-
-    """
-    original_stdout = sys.stdout
-    original_stderr = sys.stderr
-    buf_stdout = io.StringIO()
-    buf_stderr = io.StringIO()
-    sys.stdout = buf_stdout
-    sys.stderr = buf_stderr
-    try:
-        res = func(*args, **kwargs)
-    except Exception as ep:
-        log.error(ep, exc_info=True)
-        res = None
-    sys.stdout.flush()
-    sys.stderr.flush()
-    sys.stdout = original_stdout
-    sys.stderr = original_stderr
-    return buf_stdout.getvalue(), buf_stderr.getvalue(), res
-
 
 # ------------------------------------------------------------------------------------ #
 #                                         Misc                                         #

--- a/backend/generate_types.py
+++ b/backend/generate_types.py
@@ -11,6 +11,7 @@ from beets_flask.invoker import EnqueueKind
 from beets_flask.invoker.enqueue import (
     Search,
 )
+from beets_flask.server.routes.auth import AuthFlow, AuthProviderStatus
 from beets_flask.server.routes.db_models.session import MinimalSession
 from beets_flask.server.routes.inbox import InboxStats
 from beets_flask.server.routes.library.resources import (
@@ -83,6 +84,13 @@ builder.add(AlbumResponseMinimalExpanded)
 builder.add(FolderStatusUpdate)
 builder.add(JobStatusUpdate)
 builder.add(FileSystemUpdate)
+
+
+# ---------------------------------- Auth ---------------------------------- #
+
+# Auth endpoint responses
+builder.add(AuthProviderStatus)
+builder.add(AuthFlow)
 
 
 # ---------------------------------- Config ---------------------------------- #

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     "quart>=0.20.0",
     "confuse>=2.0.1",
-    "beets==2.12.0",
+    "beets==2.13.1",
     "sqlalchemy>=2.0.35",
     "rq>=2.0.0",
     "watchdog>=5.0.3",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     "quart>=0.20.0",
     "confuse>=2.0.1",
-    "beets==2.13.1",
+    "beets==2.14.0",
     "sqlalchemy>=2.0.35",
     "rq>=2.0.0",
     "watchdog>=5.0.3",
@@ -171,6 +171,6 @@ follow_untyped_imports = true
 
 [tool.uv]
 exclude-newer = "3 days"
-# python2ts is maintained alongside this project; skip the supply-chain
+# maintained alongside this project; skip the supply-chain
 # quarantine delay so new releases can be picked up immediately.
-exclude-newer-package = { python2ts = false }
+exclude-newer-package = { python2ts = false, beets = false }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 from beets import autotag
+from beets.autotag import Source
 from beets.autotag import tag_album as _tag_album
 
 from beets_flask.server.app import create_app
@@ -247,14 +248,14 @@ def mock_tag_album():
     _original_tasks = getattr(tasks_mod, "tag_album")
 
     def _cached_tag_album(
-        items,
+        source: Source,
         search_artist: str | None = None,
         search_name: str | None = None,
         search_ids: list[str] = [],
     ):
         # Compute stable hash from items and search parameters
         m = hashlib.md5()
-        for item in items:
+        for item in source.items:
             m.update(item.path)
         if search_artist:
             m.update(search_artist.encode("utf-8"))
@@ -271,7 +272,7 @@ def mock_tag_album():
                 return pickle.load(f)
 
         # Real lookup on cache miss
-        res = _tag_album(items, search_artist, search_name, search_ids)
+        res = _tag_album(source, search_artist, search_name, search_ids)
         with open(cache_file, "wb") as f:
             pickle.dump(res, f)
         return res

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -81,6 +81,23 @@ def fixture_client(testapp: Quart) -> TestClientProtocol:
     return testapp.test_client()
 
 
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Replace ``beets_flask.redis.redis_conn`` with an in-memory fake.
+
+    Note: unlike ``local_redis`` (which only mocks the rq queues), this also
+    replaces the shared connection, so code that talks to redis directly
+    (e.g. the auth flow store) works in tests.
+    """
+    from fakeredis import FakeStrictRedis
+
+    import beets_flask.redis
+
+    conn = FakeStrictRedis()
+    monkeypatch.setattr(beets_flask.redis, "redis_conn", conn)
+    return conn
+
+
 @pytest.fixture(name="runner")
 def fixture_runner(app):
     return app.test_cli_runner()

--- a/backend/tests/integration/test_routes/test_auth.py
+++ b/backend/tests/integration/test_routes/test_auth.py
@@ -1,0 +1,124 @@
+"""Tests for the auth endpoints."""
+
+from typing import ClassVar
+
+import pytest
+
+from beets_flask.extensions.auth import AuthExtension, PkceData
+from beets_flask.server.routes import auth as auth_routes
+
+PKCE = PkceData(code_verifier="verifier", state="state")
+
+
+class FakeAuth(AuthExtension):
+    """Deterministic stand-in for a real auth provider."""
+
+    name: ClassVar[str] = "fake"
+    completed_with: tuple[PkceData, str] | None = None
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        return True
+
+    def is_authenticated(self) -> bool:
+        return False
+
+    def start_authentication(self) -> tuple[PkceData, str]:
+        return PKCE, "https://example.com/authorize"
+
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        self.completed_with = (pkce, redirect_url)
+
+
+@pytest.fixture
+def fake_auth(monkeypatch) -> FakeAuth:
+    auth = FakeAuth()
+    monkeypatch.setattr(auth_routes, "AUTH_EXTENSIONS", [auth])
+    return auth
+
+
+class TestAuthProviders:
+    async def test_lists_provider_status(self, client, fake_auth):
+        response = await client.get("/api_v1/auth/providers")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == [{"name": "fake", "authenticated": False}]
+
+    async def test_skips_disabled_providers(self, client, monkeypatch):
+        class DisabledFake(FakeAuth):
+            @classmethod
+            def is_enabled(cls) -> bool:
+                return False
+
+        monkeypatch.setattr(auth_routes, "AUTH_EXTENSIONS", [DisabledFake()])
+
+        response = await client.get("/api_v1/auth/providers")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == []
+
+
+class TestAuthUrl:
+    async def test_returns_url_and_flow_id(self, client, fake_auth, fake_redis):
+        response = await client.get("/api_v1/auth/fake/url")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["url"] == "https://example.com/authorize"
+        assert data["flow_id"]
+
+        # The sensitive flow state is stored server-side, not returned.
+        assert "code_verifier" not in data
+        assert "state" not in data
+
+    async def test_unknown_provider_returns_400(self, client):
+        response = await client.get("/api_v1/auth/does-not-exist/url")
+
+        assert response.status_code == 400
+
+
+class TestAuthComplete:
+    async def test_completes_authentication(self, client, fake_auth, fake_redis):
+        redirect_url = "https://example.com/callback?code=abc123"
+
+        start = await client.get("/api_v1/auth/fake/url")
+        flow = await start.get_json()
+
+        response = await client.post(
+            "/api_v1/auth/fake/complete",
+            json={"redirect_url": redirect_url, "flow_id": flow["flow_id"]},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == {"authenticated": True}
+        assert fake_auth.completed_with == (PKCE, redirect_url)
+
+    async def test_missing_parameters_returns_400(self, client, fake_auth):
+        response = await client.post(
+            "/api_v1/auth/fake/complete", json={"redirect_url": "x"}
+        )
+        assert response.status_code == 400
+
+        response = await client.post(
+            "/api_v1/auth/fake/complete", json={"flow_id": "x"}
+        )
+        assert response.status_code == 400
+
+    async def test_unknown_flow_returns_400(self, client, fake_auth, fake_redis):
+        response = await client.post(
+            "/api_v1/auth/fake/complete",
+            json={"redirect_url": "x", "flow_id": "does-not-exist"},
+        )
+
+        assert response.status_code == 400
+
+    async def test_unknown_provider_returns_400(self, client):
+        response = await client.post(
+            "/api_v1/auth/does-not-exist/complete",
+            json={"redirect_url": "x", "flow_id": "x"},
+        )
+
+        assert response.status_code == 400

--- a/backend/tests/mixins/database.py
+++ b/backend/tests/mixins/database.py
@@ -39,7 +39,7 @@ class IsolatedDBMixin(ABC):
         _reset_database()
 
     @pytest.fixture(autouse=True, scope="class")
-    def setup_database(self):
+    def setup_database(self, db_session_factory):
         """
         Automatically reset the database before and after ALL tests in this class.
 

--- a/backend/tests/mixins/plugins.py
+++ b/backend/tests/mixins/plugins.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from abc import ABC
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 from unittest import mock
 
 import pytest
-from beets.plugins import EventType, send
+from beets.plugins import send
+
+if TYPE_CHECKING:
+    from beets.events import EventType
 
 
 class PluginEventsMixin(ABC):

--- a/backend/tests/unit/test_database/mapper/test_states.py
+++ b/backend/tests/unit/test_database/mapper/test_states.py
@@ -159,8 +159,6 @@ class TestTaskStateMapper:
         assert len(model.candidates) == 0
         assert model.progress == original.progress.progress
         assert model.choice_flag == beets_task.choice_flag
-        assert model.cur_artist == beets_task.cur_artist
-        assert model.cur_album == beets_task.cur_album
         assert model.old_paths is None
 
         # Convert back to live object
@@ -218,28 +216,30 @@ class TestTaskStateMapper:
         assert result_item.genres == ["roundtrip-genre", "foo"]
 
     def test_roundtrip_with_choice_flag_and_metadata(self):
-        """Roundtrip a task that has choice_flag, cur_artist, cur_album set."""
+        """Roundtrip a task and check its derived source survives."""
         from beets.importer import Action
 
         mapper = TaskStateMapper()
         ctx = Context()
 
-        beets_task = _make_import_task()
+        item = beets_lib_item(
+            artist="Test Artist",
+            albumartist="Test Artist",
+            album="Test Album",
+        )
+        beets_task = _make_import_task(items=[item])
         beets_task.choice_flag = Action.ASIS
-        beets_task.cur_artist = "Test Artist"
-        beets_task.cur_album = "Test Album"
 
         original = TaskState(beets_task)
 
         model: TaskStateInDb = mapper.to_db(original, ctx)
         assert model.choice_flag == Action.ASIS
-        assert model.cur_artist == "Test Artist"
-        assert model.cur_album == "Test Album"
 
         result: TaskState = mapper.from_db(model, ctx)
         assert result.task.choice_flag == Action.ASIS
-        assert result.task.cur_artist == "Test Artist"
-        assert result.task.cur_album == "Test Album"
+
+        assert result.task.source.artist == item.albumartist
+        assert result.task.source.name == item.album
 
 
 class TestCandidateStateMapper:

--- a/backend/tests/unit/test_extensions/test_tidal.py
+++ b/backend/tests/unit/test_extensions/test_tidal.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Tidal auth provider."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from beets.exceptions import UserError
+
+from beets_flask.extensions.auth import PkceData
+from beets_flask.extensions.providers.tidal import TidalAuth
+
+AUTH_URL = "https://login.tidal.com/authorize"
+TOKEN_URL = "https://auth.tidal.com/v1/oauth2/token"
+
+
+class FakeSession:
+    """Minimal stand-in for the beets tidal OAuth session."""
+
+    def __init__(self, code_verifier: str = "verifier", state: str = "state") -> None:
+        self._code_verifier = code_verifier
+        self._state = state
+        self.token: dict[str, str] | None = None
+        self.saved_token: dict[str, str] | None = None
+        self.fetch_token_kwargs: dict[str, Any] | None = None
+
+    def authorization_url(self, url: str) -> tuple[str, str]:
+        return f"{url}?code_challenge=xyz", self._state
+
+    def fetch_token(self, token_url: str, **kwargs) -> None:
+        self.fetch_token_kwargs = {"token_url": token_url, **kwargs}
+        self.token = {"access_token": "token", "refresh_token": "refresh"}
+
+    def save_token(self, token: dict[str, str]) -> None:
+        self.saved_token = token
+
+
+class FakePlugin:
+    """Minimal stand-in for beets' ``TidalPlugin``."""
+
+    def __init__(self, session: FakeSession, authenticated: bool = True) -> None:
+        self.api = SimpleNamespace(session=session)
+        self.authenticated = authenticated
+
+    def require_authentication(self, session: object) -> None:
+        if not self.authenticated:
+            raise UserError("Please login to TIDAL")
+
+
+@pytest.fixture
+def fake_plugin(monkeypatch) -> FakePlugin:
+    """Replace ``TidalAuth.tidal_plugin`` with a fake plugin instance."""
+    plugin = FakePlugin(FakeSession())
+    monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: plugin))
+    return plugin
+
+
+@pytest.fixture
+def no_plugin(monkeypatch):
+    """Make the tidal plugin unavailable."""
+    monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: None))
+
+
+class TestTidalAuth:
+    def test_start_authentication_returns_pkce_and_url(self, fake_plugin):
+        pkce, url = TidalAuth().start_authentication()
+
+        assert url == f"{AUTH_URL}?code_challenge=xyz"
+        assert pkce == PkceData(code_verifier="verifier", state="state")
+
+    def test_start_authentication_raises_without_plugin(self, no_plugin):
+        with pytest.raises(RuntimeError, match="not enabled"):
+            TidalAuth().start_authentication()
+
+    def test_complete_authentication_restores_state_and_saves_token(self, fake_plugin):
+        pkce = PkceData(code_verifier="verifier2", state="state2")
+        redirect_url = "https://example.com/callback?code=abc123"
+
+        TidalAuth().complete_authentication(pkce, redirect_url)
+
+        session = fake_plugin.api.session
+        assert session._code_verifier == "verifier2"
+        assert session._state == "state2"
+        assert session.fetch_token_kwargs == {
+            "token_url": TOKEN_URL,
+            "authorization_response": redirect_url,
+            "include_client_id": True,
+        }
+        assert session.saved_token == session.token
+
+    def test_complete_authentication_raises_without_plugin(self, no_plugin):
+        with pytest.raises(RuntimeError, match="not enabled"):
+            TidalAuth().complete_authentication(
+                PkceData(code_verifier="v", state="s"),
+                "https://example.com/callback?code=abc",
+            )
+
+    def test_is_authenticated_true_when_authenticated(self, fake_plugin):
+        assert TidalAuth().is_authenticated() is True
+
+    def test_is_authenticated_false_when_not_authenticated(self, monkeypatch):
+        plugin = FakePlugin(FakeSession(), authenticated=False)
+        monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: plugin))
+
+        assert TidalAuth().is_authenticated() is False
+
+    def test_is_authenticated_false_without_plugin(self, no_plugin):
+        assert TidalAuth().is_authenticated() is False

--- a/backend/tests/unit/test_importer/test_states.py
+++ b/backend/tests/unit/test_importer/test_states.py
@@ -135,12 +135,6 @@ class TestCandidateState(StateTest):
         assert asis_candidate.id.startswith("asis")
         assert asis_candidate.type == "album"
 
-    def test_diff_preview(self):
-        candidate = self.candidates[0]
-        diff_preview = candidate.diff_preview
-        assert isinstance(diff_preview, str)
-        assert "match album" in diff_preview
-
     def test_identify_duplicates(
         self,
     ):

--- a/backend/tests/unit/test_importer/test_states.py
+++ b/backend/tests/unit/test_importer/test_states.py
@@ -120,8 +120,6 @@ class TestCandidateState(StateTest):
         assert candidate.match == task.candidates[0]
         assert candidate.task_state == self.task_state
         assert candidate.type == "album"
-        assert candidate.cur_artist == str(task.cur_artist)
-        assert candidate.cur_album == str(task.cur_album)
         assert candidate.items == task.items
         assert candidate.tracks == candidate.match.info.tracks
         assert candidate.distance == candidate.match.distance

--- a/backend/tests/unit/test_redis.py
+++ b/backend/tests/unit/test_redis.py
@@ -67,3 +67,37 @@ async def test_wait_for_job_results():
     assert result is None
     assert job.result is None
     assert job.is_finished is True
+
+
+class TestStore:
+    """Tests for the generic TTL object store."""
+
+    def test_store_and_consume_roundtrip(self, fake_redis):
+        object_id = beets_flask.redis.store({"foo": "bar"})
+
+        assert object_id
+        assert beets_flask.redis.consume(object_id) == {"foo": "bar"}
+
+    def test_consume_is_single_use(self, fake_redis):
+        object_id = beets_flask.redis.store("value")
+
+        assert beets_flask.redis.consume(object_id) == "value"
+        assert beets_flask.redis.consume(object_id) is None
+
+    def test_consume_unknown_returns_none(self, fake_redis):
+        assert beets_flask.redis.consume("does-not-exist") is None
+
+    def test_default_ttl(self, fake_redis):
+        object_id = beets_flask.redis.store("value")
+        key = f"{beets_flask.redis._KEY_PREFIX}{object_id}"
+
+        # Matches the default of ``store(..., ttl=600)``.
+        ttl = fake_redis.ttl(key)
+        assert 0 < ttl <= 600
+
+    def test_custom_ttl(self, fake_redis):
+        object_id = beets_flask.redis.store("value", ttl=60)
+        key = f"{beets_flask.redis._KEY_PREFIX}{object_id}"
+
+        ttl = fake_redis.ttl(key)
+        assert 0 < ttl <= 60

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -7,6 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
+beets = false
 python2ts = false
 
 [[package]]
@@ -237,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "beets"
-version = "2.13.1"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -254,9 +255,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "unidecode" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/01/a8fe84c3df610e63569f51ee846d442ea7d89ef4dfc834378cebd46bfd5a/beets-2.13.1.tar.gz", hash = "sha256:ea11e0963299c1c0f728884b2896cc554747696c3ddd73d98a70cc6196ae845b", size = 2447541, upload-time = "2026-07-29T10:46:45.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/3b/359d68ce968214ffec8f55d9babe6de82794a846b5e02027f013456ef988/beets-2.14.0.tar.gz", hash = "sha256:f412c9072ddc0bed04d843546a4222fcd24c9fe64cf233517ddcdb40190feea8", size = 2481050, upload-time = "2026-09-07T20:24:53.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/22/c78c08bc1764b84d139a89692103015e574506493d664f9ceccc1dd67233/beets-2.13.1-py3-none-any.whl", hash = "sha256:6d74a610b934c8e7b86dc651ec9953b62bd5ec9c47beea10cc32ede41ea9d488", size = 625666, upload-time = "2026-07-29T10:46:44.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f5/491bd9b9e22265e538c461e90b9efc7185a493e93c6df6a6bf28244639e3/beets-2.14.0-py3-none-any.whl", hash = "sha256:270cdce1f0c441dcdb7dc9bc367b51b4a54f055e62662b3f7509aa04838d7f84", size = 650498, upload-time = "2026-09-07T20:24:51.532Z" },
 ]
 
 [[package]]
@@ -349,7 +350,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "alembic", specifier = ">=1.18.4" },
-    { name = "beets", specifier = "==2.13.1" },
+    { name = "beets", specifier = "==2.14.0" },
     { name = "cachetools", specifier = ">=5.3.3" },
     { name = "confuse", specifier = ">=2.0.1" },
     { name = "deprecated", specifier = ">=1.2.18" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "beets"
-version = "2.12.0"
+version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -245,19 +245,18 @@ dependencies = [
     { name = "jellyfish" },
     { name = "lap" },
     { name = "mediafile" },
-    { name = "numba" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "requests-ratelimiter" },
-    { name = "scipy" },
     { name = "typing-extensions" },
     { name = "unidecode" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/40/056537114e0c6df4374371341301c74b8519b571f3e67ec64f5547479a16/beets-2.12.0.tar.gz", hash = "sha256:c5e844c4785a8b2c53a791a2b7bcd5846b4d12b0e8209e8eabfee06cec57edf2", size = 2305682, upload-time = "2026-06-22T14:40:16.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/01/a8fe84c3df610e63569f51ee846d442ea7d89ef4dfc834378cebd46bfd5a/beets-2.13.1.tar.gz", hash = "sha256:ea11e0963299c1c0f728884b2896cc554747696c3ddd73d98a70cc6196ae845b", size = 2447541, upload-time = "2026-07-29T10:46:45.742Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/c9/0fe616a122713f2c933a8584df75c2cdd478a0bb3c11831a6711b5cf2c3d/beets-2.12.0-py3-none-any.whl", hash = "sha256:ed334b2e6f31c09b325e914e408818739474b2faa31149fbc04ba91e47de4ca8", size = 649953, upload-time = "2026-06-22T14:40:14.748Z" },
+    { url = "https://files.pythonhosted.org/packages/10/22/c78c08bc1764b84d139a89692103015e574506493d664f9ceccc1dd67233/beets-2.13.1-py3-none-any.whl", hash = "sha256:6d74a610b934c8e7b86dc651ec9953b62bd5ec9c47beea10cc32ede41ea9d488", size = 625666, upload-time = "2026-07-29T10:46:44.198Z" },
 ]
 
 [[package]]
@@ -350,7 +349,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "alembic", specifier = ">=1.18.4" },
-    { name = "beets", specifier = "==2.12.0" },
+    { name = "beets", specifier = "==2.13.1" },
     { name = "cachetools", specifier = ">=5.3.3" },
     { name = "confuse", specifier = ">=2.0.1" },
     { name = "deprecated", specifier = ">=1.2.18" },
@@ -1176,18 +1175,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llvmlite"
-version = "0.49.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/27/72ae94ea5c8f7349ec1c229d4cd058feb799cbd0833ad6d1b47c919b37b7/llvmlite-0.49.0.tar.gz", hash = "sha256:00f16db782f4a13c78c5804aedc434e46794a77e89999a168f9401106270e50a", size = 194467, upload-time = "2026-08-11T16:26:00.489Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/ae/3f699ebe3590e15e023a6372dd147526fd8ec398aacf9ceb844e854964a8/llvmlite-0.49.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b541c8fac3450db7574d1f53cf9dff83f285bfed9d69bf81fe71fc2a7d4f97fe", size = 40479231, upload-time = "2026-08-11T16:23:56.773Z" },
-    { url = "https://files.pythonhosted.org/packages/be/3c/e97f69c62a2d972066d9a2612ce1f3de313035ac897a5b9f787cad8b55f7/llvmlite-0.49.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6acba646d88abbc87d5c113a3d62c1fbf8b8fee11c6493f516803e30f21ae870", size = 59890658, upload-time = "2026-08-11T16:24:05.451Z" },
-    { url = "https://files.pythonhosted.org/packages/69/e6/e942ee08605fc0526ff3854260c384d8315a5830e16c4c2a5aebc14dc9bf/llvmlite-0.49.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec8ad805e7515cb8440a690eb3cef4d34acb29eef80b705ec4e1c1ad3c43c68", size = 58344481, upload-time = "2026-08-11T16:24:13.503Z" },
-    { url = "https://files.pythonhosted.org/packages/84/49/2a44871cac6b5a2fd4aabd68cfdaf6de9a5c7edb36dee5d47b77bda4b50f/llvmlite-0.49.0-cp312-cp312-win_amd64.whl", hash = "sha256:3a9c9e3af4e214acfefa4f73ebe7bc3fb35854a62b654edb3953f5ae33c08ba3", size = 41865543, upload-time = "2026-08-11T16:24:20.41Z" },
-]
-
-[[package]]
 name = "mako"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1436,22 +1423,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
-name = "numba"
-version = "0.67.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2544f4e3a61e501d6c9a5418fd4b905323222693d54a02cab0106a0af865/numba-0.67.0.tar.gz", hash = "sha256:cd75aa535b33fa05d9d930b1ae8af9f97a2881e96d72dfb38ec9b78284d9f851", size = 2836515, upload-time = "2026-08-11T23:04:00.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/58/915cddba90010348ed0444451132fdde9b000bcbaff1582029b5bf115d11/numba-0.67.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6004d8d5f28d4028687fb2d972d629295b13685943bd2ed5cd8810c3b848e219", size = 2745050, upload-time = "2026-08-11T23:03:25.607Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/38/926757caaac18a66f057d7544a63620bf360a07d281c9f7ecadd2aa83963/numba-0.67.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f63d43db06b4756424d6d2484737c902e0ae944a0eec3e8b0b4de2c695b15caa", size = 3884596, upload-time = "2026-08-11T23:03:27.688Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/6d/58291dc58da39d98b32db7f044729f6d8d4920cd9622fbab3179b54ff4c4/numba-0.67.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76d3335aaeffb9dc88309420890e73497a00be08a7530441bc2b58ffe025bfa5", size = 3585290, upload-time = "2026-08-11T23:03:29.684Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/63/ab21828b4056afed71f9ecb40f4de26c2c19de731cc001961aca74b79464/numba-0.67.0-cp312-cp312-win_amd64.whl", hash = "sha256:50e2b72406c18cda5dd7431b0082cb85ea94e06c64c33607248fc8bef92cfb81", size = 2815645, upload-time = "2026-08-11T23:03:31.732Z" },
 ]
 
 [[package]]
@@ -2151,27 +2122,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
     { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
-]
-
-[[package]]
-name = "scipy"
-version = "1.18.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/f7/240c110c08693826b4513a52f5717d62ec7c7af72f2920821247c03b17b3/scipy-1.18.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:457fd7a2a8edeb044ab6ffbc0aa03ff6cd18491356e5e0c834d76ce621b916d1", size = 31111061, upload-time = "2026-08-21T23:23:44.522Z" },
-    { url = "https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:e708533e8b2ae2497d65346538a7dcc92814410b25b81432eac66de0f2af8265", size = 28733332, upload-time = "2026-08-21T23:23:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/f6/a5b82f8abbe14d134691b8b903696f701d25a081353a29dc655c364d9e62/scipy-1.18.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7bbf207c4453ce1ad2e00b17313852b33310b83090c2311bdaf97f93c0380d12", size = 20475078, upload-time = "2026-08-21T23:23:54.138Z" },
-    { url = "https://files.pythonhosted.org/packages/23/22/0858a0bbd6b3e825ceb8cd9baf9eaf3b2f2b1d77727eb6be40500bcdc92f/scipy-1.18.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:78c0665edead396b1abb4897c41a5c1d9bf090c8a637a4c20a61678e0a264e66", size = 23108904, upload-time = "2026-08-21T23:23:57.824Z" },
-    { url = "https://files.pythonhosted.org/packages/75/9a/2e71719f31eaefe0e3a1706c4a1ded94e664bfd95ffca2b219a671faee01/scipy-1.18.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c085faa2cfa879c5141df483f836f4d691045a078224a670fa570fa01612d89", size = 34025113, upload-time = "2026-08-21T23:24:02.209Z" },
-    { url = "https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f55fa87b6c612ecd6b058f167c53231b1d14e412efe361d3d6e38b3631c73218", size = 35344199, upload-time = "2026-08-21T23:24:07.844Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/af/c5538be1792f7034c12c7db6ee67cace58253c7b87b122d68253eaf5de89/scipy-1.18.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c35d74ce0e193ff740c2f2be2ac913ddc232fe6c1ff40b26cfecb9c670c63314", size = 35639587, upload-time = "2026-08-21T23:24:13.05Z" },
-    { url = "https://files.pythonhosted.org/packages/91/4c/075e4f66471bac101141ac739e9e135549be1bae584571bd03a530c056e1/scipy-1.18.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d2924a03db38dc2e848bca2fe9f077dafb891480b91a00a0963a8cf86dfc31c1", size = 37480330, upload-time = "2026-08-21T23:24:19.608Z" },
-    { url = "https://files.pythonhosted.org/packages/39/e7/979fd14e75008623df31ba70d6bb144700f68feadcea042021c06a05bf82/scipy-1.18.1-cp312-cp312-win_amd64.whl", hash = "sha256:5e4d44984abc0020154ea81b247adeddcc3ac5527b975ff798bd1ba0adc513c2", size = 36658278, upload-time = "2026-08-21T23:24:25.463Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/e1525354ff9d7d5feb6d1b31af6d14072e5c91e9607b421fa1ec889660b3/scipy-1.18.1-cp312-cp312-win_arm64.whl", hash = "sha256:d65d448389b8436493abcf629cc94ad0cf32aecaf06e1acca1de53cc795f2f12", size = 24400588, upload-time = "2026-08-21T23:24:30.579Z" },
 ]
 
 [[package]]

--- a/docs/develop/resources/extensions.md
+++ b/docs/develop/resources/extensions.md
@@ -31,4 +31,5 @@ modular and make individual capabilities easy to extend.
 :maxdepth: 1
 
 extensions/art.md
+extensions/auth.md
 ```

--- a/docs/develop/resources/extensions/auth.md
+++ b/docs/develop/resources/extensions/auth.md
@@ -1,0 +1,42 @@
+# Auth extension
+
+The auth extension provides authentication with external services for beets
+plugins that need it. Some plugins only work after the user has authenticated
+with a service (e.g. Tidal), which normally means running a command like
+`beet tidal --auth` on the command line. The auth extension exposes the same
+flow through the `/auth` API endpoints, so authentication can happen in the
+browser from the beets-flask web UI.
+
+## How it works
+
+Authentication uses the PKCE flow (RFC 7636): the user authenticates in their
+browser, and the resulting authorization code is exchanged for a token. A
+provider implements two steps:
+
+1. `start_authentication()` returns the URL the user must visit, together with
+   sensitive flow state (the PKCE code verifier and CSRF state).
+2. After the user logs in, the service redirects back with an authorization
+   code. The caller passes the redirect URL (plus the flow state) to
+   `complete_authentication()`, which exchanges the code for a token and
+   persists it.
+
+The extension itself does not persist any state: the caller keeps the flow
+state server-side between the two steps and hands the client only an opaque
+`flow_id`. The provider is responsible for persisting the token once the flow
+is complete.
+
+## Adding a provider
+
+Providers live in `beets_flask/extensions/providers/`. A provider subclasses
+`AuthExtension` and implements `name`, `is_enabled()`, `is_authenticated()`,
+`start_authentication()` and `complete_authentication()`, then registers in
+the `AUTH_EXTENSIONS` list in `beets_flask/extensions/providers/__init__.py`.
+
+For a first example, see
+`beets_flask/extensions/providers/tidal.py`. It reuses the OAuth session of
+beets' tidal plugin to generate the authorization URL and exchange the code,
+and the plugin itself saves the resulting token.
+
+The flow state is sensitive and single-use: the code verifier must never reach
+the client, and a consumed or expired `flow_id` cannot be replayed to complete
+a flow.

--- a/docs/plugins/supported-plugins.md
+++ b/docs/plugins/supported-plugins.md
@@ -93,3 +93,11 @@ All extensions are built on beets-flask's
 
 The Art extension provides cover artwork for external release URLs. It allows
 beets-flask to show artwork previews for releases before they are imported.
+
+(auth)=
+
+### Auth
+
+Some beets plugins require you to authenticate with an external service to use them.
+The Auth extension lets them request that authentication through the beets-flask web UI,
+so you don't need to use the beets CLI directly.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,70 @@
+/** API functions and hooks for the auth endpoints (i.e. /api_v1/auth). */
+
+import {
+    queryOptions,
+    useMutation,
+    UseMutationOptions,
+    useQuery,
+} from '@tanstack/react-query';
+
+import { AuthFlow, AuthProviderStatus } from '@/pythonTypes';
+
+import { APIError, queryClient } from './common';
+
+/* -------------------------------- Queries -------------------------------- */
+
+export const authProvidersQueryOptions = () =>
+    queryOptions<AuthProviderStatus[], APIError>({
+        queryKey: ['auth', 'providers'],
+        queryFn: async () => {
+            const response = await fetch('/auth/providers');
+            return (await response.json()) as AuthProviderStatus[];
+        },
+    });
+
+/** Returns the full query result; `data` is undefined while loading or on error. */
+export const useAuthProviders = () => useQuery(authProvidersQueryOptions());
+
+/* ------------------------------- Mutations ------------------------------- */
+
+/** Start the PKCE flow: returns the URL to visit plus the single-use ``flow_id``. */
+export const startAuthMutationOptions = (
+    provider: string
+): UseMutationOptions<AuthFlow, APIError, void> => ({
+    mutationFn: async () => {
+        const response = await fetch(`/auth/${provider}/url`);
+        return (await response.json()) as AuthFlow;
+    },
+});
+
+/** Combined PKCE flow hook: ``start`` returns url + ``flow_id``, ``complete`` finishes it. */
+export const useAuth = (provider: string) => {
+    const start = useMutation(startAuthMutationOptions(provider));
+    const complete = useMutation(completeAuthMutationOptions(provider));
+    return { start, complete };
+};
+
+/** Complete the flow: exchange the redirect URL for a token, then refresh the providers. */
+export const completeAuthMutationOptions = (
+    provider: string
+): UseMutationOptions<
+    { authenticated: boolean },
+    APIError,
+    { flow_id: string; redirect_url: string }
+> => ({
+    mutationFn: async ({ flow_id, redirect_url }) => {
+        const response = await fetch(`/auth/${provider}/complete`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ flow_id, redirect_url }),
+        });
+        return (await response.json()) as { authenticated: boolean };
+    },
+    onSuccess: async () => {
+        await queryClient.invalidateQueries({
+            queryKey: ['auth', 'providers'],
+        });
+    },
+});

--- a/frontend/src/components/auth/AuthDialog.tsx
+++ b/frontend/src/components/auth/AuthDialog.tsx
@@ -1,0 +1,140 @@
+import { UserRoundKeyIcon } from 'lucide-react';
+import { useState } from 'react';
+import {
+    Button,
+    DialogContent,
+    Link,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+
+import { useAuth } from '@/api/auth';
+import { Dialog } from '@/components/common/dialogs';
+import { AuthFlow } from '@/pythonTypes';
+
+/** Modal for the PKCE flow of a single provider.
+ *
+ * 1. "Open login page" starts the flow and opens the provider's login URL.
+ * 2. The user pastes the redirect URL they were sent to after logging in.
+ * 3. "Complete" exchanges the code for a token and closes the dialog.
+ */
+export function AuthDialog({
+    provider,
+    onClose,
+}: {
+    provider: string;
+    onClose: () => void;
+}) {
+    const { start, complete } = useAuth(provider);
+    const [flow, setFlow] = useState<AuthFlow | null>(null);
+    const [redirectUrl, setRedirectUrl] = useState('');
+    const [popupBlocked, setPopupBlocked] = useState(false);
+
+    const handleOpenLogin = () => {
+        start.mutate(undefined, {
+            onSuccess: (flow) => {
+                setFlow(flow);
+                setRedirectUrl('');
+                // `noopener` makes window.open() return null when the popup is
+                // blocked, in which case we offer the URL as a link instead.
+                setPopupBlocked(
+                    !window.open(flow.url, '_blank', 'noopener,noreferrer')
+                );
+            },
+        });
+    };
+
+    const handleComplete = () => {
+        if (!flow) return;
+        complete.mutate(
+            { flow_id: flow.flow_id, redirect_url: redirectUrl.trim() },
+            { onSuccess: onClose }
+        );
+    };
+
+    const error = start.error ?? complete.error;
+
+    const handleClose = (
+        _event: object,
+        reason: 'backdropClick' | 'escapeKeyDown' | 'xIconClick'
+    ) => {
+        // Don't close on backdrop clicks; the in-progress flow would be lost.
+        if (reason === 'backdropClick') return;
+        onClose();
+    };
+
+    return (
+        <Dialog
+            open
+            onClose={handleClose}
+            title={`Authenticate ${provider}`}
+            title_icon={<UserRoundKeyIcon />}
+        >
+            <DialogContent>
+                <Stack spacing={2}>
+                    <Typography variant="body2">
+                        To use {provider} as a metadata source, log in with your
+                        account:
+                    </Typography>
+                    <ol style={{ margin: 0, paddingLeft: 20 }}>
+                        <li>Click &quot;Open login page&quot; below.</li>
+                        <li>Log in and approve the access.</li>
+                        <li>
+                            You will be redirected to a page that fails to load;
+                            copy the full URL from the address bar.
+                        </li>
+                        <li>
+                            Paste it into the field below and click
+                            &quot;Complete&quot;.
+                        </li>
+                    </ol>
+                    <Button
+                        variant="contained"
+                        onClick={handleOpenLogin}
+                        disabled={start.isPending}
+                    >
+                        {start.isPending ? 'Opening...' : 'Open login page'}
+                    </Button>
+                    <TextField
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        label="Redirect URL"
+                        placeholder="https://localhost/?code=...&state=..."
+                        value={redirectUrl}
+                        onChange={(e) => setRedirectUrl(e.target.value)}
+                        disabled={complete.isPending}
+                    />
+                    {popupBlocked && flow && (
+                        <Typography variant="body2">
+                            Your browser blocked the popup. Open{' '}
+                            <Link
+                                href={flow.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                the login page
+                            </Link>{' '}
+                            manually.
+                        </Typography>
+                    )}
+                    {error && (
+                        <Typography variant="body2" color="error">
+                            {error.message}
+                        </Typography>
+                    )}
+                    <Button
+                        variant="contained"
+                        onClick={handleComplete}
+                        disabled={
+                            !flow || !redirectUrl.trim() || complete.isPending
+                        }
+                    >
+                        {complete.isPending ? 'Completing...' : 'Complete'}
+                    </Button>
+                </Stack>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/components/auth/AuthRequiredBanner.tsx
+++ b/frontend/src/components/auth/AuthRequiredBanner.tsx
@@ -1,0 +1,75 @@
+import { UserRoundKeyIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button, Typography } from '@mui/material';
+
+import { useAuthProviders } from '@/api/auth';
+import { AuthDialog } from '@/components/auth/AuthDialog';
+
+/** Shown when an enabled extension requires authentication.
+ *
+ * Rendered at the top of the inbox index page; not page-specific though.
+ */
+export function AuthRequiredBanner() {
+    const { data: providers, isLoading } = useAuthProviders();
+    const [authProvider, setAuthProvider] = useState<string | null>(null);
+
+    // Don't flash the banner while the providers are still loading.
+    if (isLoading) {
+        return null;
+    }
+
+    const missing = (providers ?? []).filter((p) => !p.authenticated);
+    if (missing.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <Alert
+                severity="warning"
+                icon={<UserRoundKeyIcon />}
+                sx={{ '.MuiAlert-message': { width: '100%' } }}
+            >
+                <AlertTitle>Authentication required</AlertTitle>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                    <Typography variant="body2">
+                        We detected that some metadata sources do not have valid
+                        credentials. Importing and tagging may fail or crash
+                        while such sources are enabled. Please authenticate with
+                        the following providers or disable them in your beets
+                        configuration.
+                    </Typography>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 1,
+                            marginTop: 1,
+                            justifyContent: 'center',
+                            '*': {
+                                maxWidth: '400px',
+                            },
+                        }}
+                    >
+                        {missing.map((provider) => (
+                            <Button
+                                key={provider.name}
+                                variant="outlined"
+                                onClick={() => setAuthProvider(provider.name)}
+                            >
+                                Authenticate {provider.name}
+                            </Button>
+                        ))}
+                    </Box>
+                </Box>
+            </Alert>
+            {authProvider && (
+                <AuthDialog
+                    key={authProvider}
+                    provider={authProvider}
+                    onClose={() => setAuthProvider(null)}
+                />
+            )}
+        </>
+    );
+}

--- a/frontend/src/pythonTypes.ts
+++ b/frontend/src/pythonTypes.ts
@@ -138,6 +138,16 @@ export interface BeetsFlaskSchema {
     num_preview_workers: number;
 }
 
+export interface AuthProviderStatus {
+    name: string;
+    authenticated: boolean;
+}
+
+export interface AuthFlow {
+    url: string;
+    flow_id: string;
+}
+
 export interface Archive extends FileSystemItem {
     is_album: boolean;
 }

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -14,6 +14,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Action, useConfig } from '@/api/config';
 import { inboxQueryOptions, walkFolder } from '@/api/inbox';
 import { ensureMinimalSessions, ensureStatuses } from '@/api/session';
+import { AuthRequiredBanner } from '@/components/auth/AuthRequiredBanner';
 import { MatchChip, StyledChip } from '@/components/common/chips';
 import { Dialog } from '@/components/common/dialogs';
 import {
@@ -99,6 +100,7 @@ function RouteComponent() {
                     flexDirection: 'column',
                 }}
             >
+                <AuthRequiredBanner />
                 <FileUploadProvider>
                     {inboxes.map((folder) => (
                         <FolderSelectionProvider key={folder.full_path}>

--- a/frontend/src/routes/version.tsx
+++ b/frontend/src/routes/version.tsx
@@ -1,8 +1,10 @@
 import { ChevronDownIcon } from 'lucide-react';
+import { lazy, Suspense, useState } from 'react';
 import {
     AccordionDetails,
     AccordionSummary,
     Box,
+    Button,
     Divider,
     Paper,
     Typography,
@@ -12,15 +14,43 @@ import { Accordion } from '@mui/material';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
+import { authProvidersQueryOptions } from '@/api/auth';
 import { configYamlQueryOptions, useConfig } from '@/api/config';
 import { SourceTypeIcon } from '@/components/common/icons';
 import { PageWrapper } from '@/components/common/page';
+import { AuthProviderStatus } from '@/pythonTypes';
 
 import { VersionString } from './_frontpage';
+
+/** Lazily loaded so the dialog chunk is only fetched when first opened. */
+const AuthDialog = lazy(() =>
+    import('@/components/auth/AuthDialog').then((m) => ({
+        default: m.AuthDialog,
+    }))
+);
 
 export const Route = createFileRoute('/version')({
     component: RouteComponent,
 });
+
+/** Shared styling so all accordions on this page look alike. */
+const accordionSx = {
+    boxShadow: 'none',
+    border: 'none',
+    outline: 'none',
+    '::before': { backgroundColor: 'unset' },
+    '.MuiAccordionSummary-content': {
+        padding: 0,
+        margin: 0,
+    },
+    '.MuiAccordionSummary-root': {
+        height: 'auto',
+        padding: 0,
+        display: 'flex',
+        alignItems: 'flex-start',
+        minHeight: 'auto',
+    },
+};
 
 /** A relative simple page showing the current version */
 function RouteComponent() {
@@ -67,6 +97,7 @@ function RouteComponent() {
                     <Version />
                     <DataSources />
                     <Plugins />
+                    <Extensions />
                     <Config />
                 </Box>
             </Paper>
@@ -179,6 +210,108 @@ function Plugins() {
     );
 }
 
+/** Section listing enabled beets-flask extensions. */
+function Extensions() {
+    return (
+        <>
+            <Typography
+                component="label"
+                variant="caption"
+                fontWeight="bold"
+                color="textSecondary"
+            >
+                Extensions
+            </Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    maxWidth: '100%',
+                    overflow: 'hidden',
+                    gap: 1,
+                }}
+            >
+                <Accordion disableGutters sx={accordionSx}>
+                    <AccordionSummary expandIcon={<ChevronDownIcon />}>
+                        <Typography fontFamily="monospace">Auth</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                        <AuthExtensions />
+                    </AccordionDetails>
+                </Accordion>
+            </Box>
+        </>
+    );
+}
+
+/** Auth extensions content: per-provider status with (re-)authentication. */
+function AuthExtensions() {
+    const { data: providers } = useSuspenseQuery(authProvidersQueryOptions());
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {providers.length === 0 ? (
+                <Typography
+                    variant="body1"
+                    component="span"
+                    fontFamily="monospace"
+                >
+                    none enabled
+                </Typography>
+            ) : (
+                providers.map((provider) => (
+                    <AuthProviderRow key={provider.name} provider={provider} />
+                ))
+            )}
+        </Box>
+    );
+}
+
+/** A single auth provider row: name, status and a (re-)auth button. */
+function AuthProviderRow({ provider }: { provider: AuthProviderStatus }) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                <Typography
+                    variant="body1"
+                    component="span"
+                    fontFamily="monospace"
+                >
+                    {provider.name}
+                </Typography>
+                <Typography
+                    variant="body1"
+                    component="span"
+                    color={provider.authenticated ? 'success' : 'error'}
+                >
+                    {provider.authenticated
+                        ? 'authenticated'
+                        : 'not authenticated'}
+                </Typography>
+                <Button
+                    size="small"
+                    sx={{ ml: 'auto' }}
+                    onClick={() => setOpen(true)}
+                >
+                    {provider.authenticated
+                        ? 'Re-authenticate'
+                        : 'Authenticate'}
+                </Button>
+            </Box>
+            {open && (
+                <Suspense fallback={null}>
+                    <AuthDialog
+                        provider={provider.name}
+                        onClose={() => setOpen(false)}
+                    />
+                </Suspense>
+            )}
+        </>
+    );
+}
+
 function Config() {
     const theme = useTheme();
 
@@ -207,26 +340,7 @@ function Config() {
                     gap: 1,
                 }}
             >
-                <Accordion
-                    disableGutters
-                    sx={{
-                        boxShadow: 'none',
-                        border: 'none',
-                        outline: 'none',
-                        '::before': { backgroundColor: 'unset' },
-                        '.MuiAccordionSummary-content': {
-                            padding: 0,
-                            margin: 0,
-                        },
-                        button: {
-                            height: 'auto',
-                            padding: 0,
-                            display: 'flex',
-                            alignItems: 'flex-start',
-                            minHeight: 'auto',
-                        },
-                    }}
-                >
+                <Accordion disableGutters sx={accordionSx}>
                     <AccordionSummary expandIcon={<ChevronDownIcon />}>
                         <Typography fontFamily="monospace">
                             Beets configuration
@@ -249,26 +363,7 @@ function Config() {
                         </Typography>
                     </AccordionDetails>
                 </Accordion>
-                <Accordion
-                    disableGutters
-                    sx={{
-                        boxShadow: 'none',
-                        border: 'none',
-                        outline: 'none',
-                        '::before': { backgroundColor: 'unset' },
-                        '.MuiAccordionSummary-content': {
-                            padding: 0,
-                            margin: 0,
-                        },
-                        button: {
-                            height: 'auto',
-                            padding: 0,
-                            display: 'flex',
-                            alignItems: 'flex-start',
-                            minHeight: 'auto',
-                        },
-                    }}
-                >
+                <Accordion disableGutters sx={accordionSx}>
                     <AccordionSummary expandIcon={<ChevronDownIcon />} sx={{}}>
                         <Typography fontFamily="monospace">
                             Beets Flask configuration


### PR DESCRIPTION
##  Summary                                                                                                                                                      
                                                                                                                                                              
Introduces a generic authentication extension system with a new Tidal provider, exposed to the frontend through /auth endpoints (provider status, PKCE flow  start/complete) backed by a Redis flow-state store. This lets plugins authenticate directly from the web UI, without needing the beets CLI. 
 
 ### Frontend                                                                                                                                                     
                                                                                                                                                              
 - Auth API layer (query options + mutations) and a dialog that walks the PKCE flow                                                                           
 - Banner on the inbox page prompting for providers missing credentials                                                                                       
 - Debug/version page lists auth extensions with per-provider status and re-authentication                                                                    
                                                                                                                                                              
 ### Backend                                                                                                                                                      
                                                                                                                                                              
 - Extensible auth interface with a Tidal implementation                                                                                                      
 - Redis-backed single-use flow store                                                                                                                         
 - Integration tests for the auth endpoints; unit tests for Tidal and the Redis store    

## Screenshots

<img width="1266" height="292" alt="image" src="https://github.com/user-attachments/assets/ac378682-7f59-4472-b547-8e47f6aec8ff" />#diff-5506c6a2b1a470e906ac8db296ca5e0a3f2126f08a3b801127e38790d9bd9d80R1-R124)

<img width="946" height="735" alt="image" src="https://github.com/user-attachments/assets/0745cd93-ab7d-40c2-9c37-622e7b983e3d" />


## TODOs

- [ ] Documentation for the new extension type
- [ ] Documentation for the tidal plugin