### PR TITLE
Enhances `tidal` compatibility

### DIFF
--- a/backend/beets_flask/extensions/__init__.py
+++ b/backend/beets_flask/extensions/__init__.py
@@ -14,3 +14,13 @@ artwork resolution). The module defines an abstract base class describing the
 extension interface, while concrete implementations live in
 `extensions/providers/` (one module per provider).
 """
+
+from .art import ArtResult, ArtSource
+from .auth import AuthExtension, PkceData
+
+__all__ = [
+    "ArtResult",
+    "ArtSource",
+    "AuthExtension",
+    "PkceData",
+]

--- a/backend/beets_flask/extensions/auth.py
+++ b/backend/beets_flask/extensions/auth.py
@@ -1,0 +1,76 @@
+"""Auth extension: Provides generic authentication support for plugins that need it.
+
+Some plugins needs authentication to access their API or work at all, e.g. tidal needs
+you to run `beet tidal --auth`
+"""
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class PkceData:
+    """Sensitive PKCE flow state (RFC 7636).
+
+    The ``code_verifier`` is required to redeem the authorization code, and
+    ``state`` binds the redirect URL to the flow (CSRF). Together they make
+    the flow stateless across processes: they must be persisted server-side
+    between the two steps and must never reach the client.
+    """
+
+    code_verifier: str
+    state: str
+
+
+class AuthExtension:
+    """Interface for an authentication extension.
+
+    Provides a way to check for authentication and to perform authentication if needed.
+
+    Only the PKCE flow (see RFC 7636) is supported right now: the user authenticates in
+    their browser, and the resulting authorization code is exchanged for a token.
+    Extensions implement this as two steps:
+
+    1. :meth:`start_authentication` returns the sensitive :class:`PkceData`
+       plus the URL the user must visit.
+    2. After the user logs in, the service redirects back to a URL
+       containing an authorization code. The caller passes that redirect
+       URL (together with the flow state) to
+       :meth:`complete_authentication`, which exchanges the code for a
+       token and persists it.
+
+    The extension itself does not persist any state; the caller is
+    responsible for keeping the (sensitive) flow state server-side between
+    the two steps, e.g. in the app's storage backend.
+
+    Other flows (e.g. client credentials) may be added later if a plugin
+    requires them.
+    """
+
+    name: ClassVar[str]
+
+    @classmethod
+    @abstractmethod
+    def is_enabled(cls) -> bool:
+        """Return whether the provider is available (e.g. its plugin is enabled)."""
+
+    @abstractmethod
+    def is_authenticated(self) -> bool:
+        """Return whether the user is authenticated."""
+
+    @abstractmethod
+    def start_authentication(self) -> tuple[PkceData, str]:
+        """Start the PKCE flow.
+
+        Returns the sensitive :class:`PkceData` and the URL the user must
+        visit.
+        """
+
+    @abstractmethod
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        """Complete the flow using the state from ``start_authentication``.
+
+        The ``redirect_url`` contains the authorization code, which is
+        exchanged for a token.
+        """

--- a/backend/beets_flask/extensions/providers/__init__.py
+++ b/backend/beets_flask/extensions/providers/__init__.py
@@ -1,7 +1,7 @@
-"""Concrete art providers.
+"""Concrete providers.
 
-Each module implements one `ArtSource`. This package holds the
-hard-coded list of sources; a registry may replace this later.
+Each module implements one `ArtSource` and/or `AuthExtension`. This package
+holds the hard-coded list of sources; a registry may replace this later.
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .file import FileArtSource
 from .musicbrainz import MusicbrainzArtSource
 from .spotify import SpotifyArtSource
+from .tidal import TidalAuth
 
 # TODO: We should add a proper registry here to simplify this
 # Not needed for now but once we add more parts to the extension system
@@ -20,6 +21,12 @@ ART_SOURCES = [
     MusicbrainzArtSource(),
 ]
 
+
+AUTH_EXTENSIONS = [
+    TidalAuth(),
+]
+
 __all__ = [
     "ART_SOURCES",
+    "AUTH_EXTENSIONS",
 ]

--- a/backend/beets_flask/extensions/providers/__init__.py
+++ b/backend/beets_flask/extensions/providers/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from .file import FileArtSource
 from .musicbrainz import MusicbrainzArtSource
 from .spotify import SpotifyArtSource
-from .tidal import TidalAuth
+from .tidal import TidalArtSource, TidalAuth
 
 # TODO: We should add a proper registry here to simplify this
 # Not needed for now but once we add more parts to the extension system
@@ -19,6 +19,7 @@ ART_SOURCES = [
     FileArtSource(),
     SpotifyArtSource(),
     MusicbrainzArtSource(),
+    TidalArtSource(),
 ]
 
 

--- a/backend/beets_flask/extensions/providers/tidal.py
+++ b/backend/beets_flask/extensions/providers/tidal.py
@@ -1,17 +1,23 @@
+"""Tidal provider: authentication and album art resolution."""
+
 from __future__ import annotations
 
+import asyncio
+import re
 from functools import cache
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal, NotRequired, TypedDict, cast
 
+import aiohttp
 from beets import plugins as beets_plugins
 from beets.exceptions import UserError
 
 from beets_flask.logger import log
 
-from .. import AuthExtension, PkceData
+from .. import ArtResult, ArtSource, AuthExtension, PkceData
 
 if TYPE_CHECKING:
     from beetsplug.tidal import TidalPlugin
+    from beetsplug.tidal.api_types import AlbumDocument
 
 
 class TidalAuth(AuthExtension):
@@ -98,3 +104,96 @@ class TidalAuth(AuthExtension):
             include_client_id=True,
         )
         session.save_token(session.token)
+
+
+# The beets tidal plugin does not type the artwork resources, so the
+# cover-related parts of its ``AlbumDocument`` are defined here.
+class ArtworkFileMeta(TypedDict):
+    width: int
+    height: int
+
+
+class ArtworkFile(TypedDict):
+    href: str
+    meta: ArtworkFileMeta
+
+
+class ArtworkAttributes(TypedDict):
+    mediaType: NotRequired[str]
+    files: list[ArtworkFile]
+
+
+class TidalArtwork(TypedDict):
+    id: str
+    type: Literal["artworks"]
+    attributes: NotRequired[ArtworkAttributes]
+
+
+# Anchored via `match` (start of URL), so a matching host cannot be
+# smuggled in via a subdomain, path segment, or query parameter.
+_TIDAL_ALBUM_URL = re.compile(
+    r"https?://(?:listen\.)?tidal\.com/(?:browse/)?album/(\d+)"
+)
+
+
+class TidalArtSource(ArtSource):
+    """Resolve album art for Tidal URLs via the authenticated Tidal API.
+
+    The cover artwork (with file URLs for all sizes) is fetched through the
+    beets tidal plugin's API; small preview sizes are returned first.
+    """
+
+    name: ClassVar[str] = "tidal"
+    priority: ClassVar[int] = 10
+
+    def matches(self, url: str) -> bool:
+        return self._extract_album_id(url) is not None
+
+    async def get_art(
+        self, url: str, session: aiohttp.ClientSession
+    ) -> ArtResult | None:
+        album_id = self._extract_album_id(url)
+        if album_id is None:
+            return None
+
+        # The plugin API is blocking IO (requests); keep it off the event loop.
+        urls = await asyncio.to_thread(self._fetch_cover_urls, album_id)
+        return ArtResult.from_urls(urls) if urls else None
+
+    def _fetch_cover_urls(self, album_id: str) -> list[str]:
+        """Return cover file URLs for a Tidal album, small previews first."""
+        plugin = TidalAuth.tidal_plugin()
+        if plugin is None:
+            log.info("Tidal plugin not enabled; cannot fetch art for %s", album_id)
+            return []
+
+        try:
+            doc = plugin.api.get_albums(ids=[album_id], include=["coverArt"])
+        except Exception as err:
+            log.warning("Error fetching Tidal album %s: %s", album_id, err)
+            return []
+
+        files = [
+            f
+            for f in self._extract_cover_files(doc)
+            if f.get("href") and int(f["meta"]["width"]) >= 200
+        ]
+        # Smallest first (but skipping tiny thumbnails), so the art route
+        # serves a cheap preview.
+        return [f["href"] for f in sorted(files, key=lambda f: f["meta"]["width"])]
+
+    @staticmethod
+    def _extract_cover_files(doc: AlbumDocument) -> list[ArtworkFile]:
+        """Return the cover artwork file list from an AlbumDocument, or []."""
+        for included in doc.get("included", []):
+            if included["type"] == "artworks":
+                artwork = cast(TidalArtwork, included)
+                attributes = artwork.get("attributes")
+                return attributes.get("files", []) if attributes else []
+        return []
+
+    @staticmethod
+    def _extract_album_id(url: str) -> str | None:
+        """Return the album id from a Tidal album URL, else None."""
+        match = _TIDAL_ALBUM_URL.match(url)
+        return match.group(1) if match else None

--- a/backend/beets_flask/extensions/providers/tidal.py
+++ b/backend/beets_flask/extensions/providers/tidal.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from functools import cache
+from typing import TYPE_CHECKING, ClassVar
+
+from beets import plugins as beets_plugins
+from beets.exceptions import UserError
+
+from beets_flask.logger import log
+
+from .. import AuthExtension, PkceData
+
+if TYPE_CHECKING:
+    from beetsplug.tidal import TidalPlugin
+
+
+class TidalAuth(AuthExtension):
+    """Authenticate with Tidal.
+
+    Implements the same auth flow as in beets' Tidal plugin, using the
+    `requests-oauthlib` session to generate the auth URL and exchange the code for a
+    token.
+    """
+
+    name: ClassVar[str] = "tidal"
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        return cls.tidal_plugin() is not None
+
+    @classmethod
+    @cache
+    def tidal_plugin(cls) -> TidalPlugin | None:
+        """Return beets' loaded Tidal plugin, if enabled."""
+        try:
+            from beetsplug.tidal import TidalPlugin as _TidalPlugin
+        except ImportError as err:
+            log.debug("Tidal plugin is unavailable: %s", err)
+            return None
+
+        return next(
+            (
+                plugin
+                for plugin in beets_plugins.find_plugins()
+                if isinstance(plugin, _TidalPlugin)
+            ),
+            None,
+        )
+
+    def is_authenticated(self) -> bool:
+        """Check if the user is authenticated with Tidal."""
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            return False
+
+        # Raises UserError if not authenticated
+        try:
+            plugin.require_authentication()
+        except UserError:
+            return False
+
+        return True
+
+    def start_authentication(self) -> tuple[PkceData, str]:
+        """Start the PKCE flow: build the login URL and return the flow state.
+
+        The PKCE verifier and CSRF state live on the OAuth session object,
+        which is process-local, so they are returned here as sensitive
+        :class:`PkceData`. The caller is responsible for persisting them
+        server-side until the flow is completed.
+        """
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            raise RuntimeError("The Tidal plugin is not enabled.")
+
+        session = plugin.api.session
+        auth_url, state = session.authorization_url("https://login.tidal.com/authorize")
+        pkce = PkceData(code_verifier=session._code_verifier, state=state)
+        return pkce, auth_url
+
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        """Exchange the auth code from ``redirect_url`` for a token and save it.
+
+        The PKCE state from ``pkce`` is restored on the OAuth session before
+        the exchange, so it can run on any worker.
+        """
+
+        plugin = self.tidal_plugin()
+        if plugin is None:
+            raise RuntimeError("The Tidal plugin is not enabled.")
+
+        session = plugin.api.session
+        session._state = pkce.state
+        session._code_verifier = pkce.code_verifier
+        session.fetch_token(
+            "https://auth.tidal.com/v1/oauth2/token",
+            authorization_response=redirect_url,
+            include_client_id=True,
+        )
+        session.save_token(session.token)

--- a/backend/beets_flask/redis.py
+++ b/backend/beets_flask/redis.py
@@ -1,7 +1,10 @@
 import asyncio
+import json
 import os
+import secrets
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import redis
 from rq import Queue
@@ -19,6 +22,37 @@ import_queue = Queue("import", connection=redis_conn, default_timeout=600)
 
 
 queues = [preview_queue, import_queue]
+
+
+_KEY_PREFIX = "store:"
+
+
+def store(value: Any, ttl: int = 600) -> str:
+    """Store a JSON-serializable value and return an opaque id (with a TTL).
+
+    The value expires after ``ttl`` seconds. The returned id is what the
+    caller hands to :func:`consume` to retrieve (and delete) the value.
+    """
+    object_id = secrets.token_urlsafe(32)
+    redis_conn.set(
+        f"{_KEY_PREFIX}{object_id}",
+        json.dumps(value),
+        ex=ttl,
+    )
+    return object_id
+
+
+def consume(object_id: str) -> Any | None:
+    """Retrieve and delete a stored value by id (single-use).
+
+    Returns the stored value, or None if the id is unknown or has expired.
+    """
+    key = f"{_KEY_PREFIX}{object_id}"
+    raw = redis_conn.get(key)
+    if raw is None:
+        return None
+    redis_conn.delete(key)
+    return json.loads(raw)
 
 
 async def wait_for_job_results(
@@ -71,4 +105,6 @@ __all__ = [
     "preview_queue",
     "redis_conn",
     "wait_for_job_results",
+    "store",
+    "consume",
 ]

--- a/backend/beets_flask/server/routes/__init__.py
+++ b/backend/beets_flask/server/routes/__init__.py
@@ -1,6 +1,7 @@
 from quart import Blueprint, Quart
 
 from .art_preview import art_blueprint
+from .auth import auth_bp
 from .config import config_bp
 from .db_models import register_state_models
 from .exception import error_bp
@@ -14,6 +15,7 @@ backend_bp = Blueprint("backend", __name__, url_prefix="/api_v1")
 
 # Register all backend blueprints
 backend_bp.register_blueprint(art_blueprint)
+backend_bp.register_blueprint(auth_bp)
 backend_bp.register_blueprint(config_bp)
 backend_bp.register_blueprint(error_bp)
 backend_bp.register_blueprint(file_upload_bp)

--- a/backend/beets_flask/server/routes/auth.py
+++ b/backend/beets_flask/server/routes/auth.py
@@ -38,13 +38,15 @@ async def get_providers() -> list[AuthProviderStatus]:
     return providers
 
 
-class AuthUrlResponse(TypedDict):
+class AuthFlow(TypedDict):
+    """In-progress PKCE flow handed to the client (see ``AuthExtension``)."""
+
     url: str
     flow_id: str
 
 
 @auth_bp.route("/<name>/url", methods=["GET"])
-async def get_authentication_url(name: str) -> dict[str, str]:
+async def get_authentication_url(name: str) -> AuthFlow:
     """Start the PKCE flow for ``name``.
 
     Returns the URL the user must visit together with an opaque ``flow_id``

--- a/backend/beets_flask/server/routes/auth.py
+++ b/backend/beets_flask/server/routes/auth.py
@@ -1,0 +1,107 @@
+"""Auth endpoints for the frontend.
+
+Exposes the registered auth extensions (see `beets_flask.extensions.providers`)
+to the frontend: checking which providers are available and running the PKCE
+authentication flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TypedDict
+
+from quart import Blueprint, jsonify, request
+
+from beets_flask.extensions.auth import AuthExtension, PkceData
+from beets_flask.extensions.providers import AUTH_EXTENSIONS
+from beets_flask.redis import consume, store
+from beets_flask.server.exceptions import InvalidUsageException
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+class AuthProviderStatus(TypedDict):
+    name: str
+    authenticated: bool
+
+
+@auth_bp.route("/providers", methods=["GET"])
+async def get_providers() -> list[AuthProviderStatus]:
+    """List all registered auth providers with their authentication status."""
+    providers: list[AuthProviderStatus] = [
+        {
+            "name": ext.name,
+            "authenticated": ext.is_authenticated(),
+        }
+        for ext in _get_auth_extensions()
+    ]
+    return providers
+
+
+class AuthUrlResponse(TypedDict):
+    url: str
+    flow_id: str
+
+
+@auth_bp.route("/<name>/url", methods=["GET"])
+async def get_authentication_url(name: str) -> dict[str, str]:
+    """Start the PKCE flow for ``name``.
+
+    Returns the URL the user must visit together with an opaque ``flow_id``
+    that must be passed back to the ``complete`` endpoint. The sensitive
+    flow state stays in the server-side store.
+    """
+    ext = _get_auth_extension(name)
+    try:
+        pkce, url = ext.start_authentication()
+    except RuntimeError as err:
+        raise InvalidUsageException(str(err)) from err
+    flow_id = store(asdict(pkce))
+    return {"url": url, "flow_id": flow_id}
+
+
+@auth_bp.route("/<name>/complete", methods=["POST"])
+async def complete_authentication(name: str):
+    """Complete the PKCE flow for ``name`` using the redirect URL.
+
+    The request body must contain the ``flow_id`` returned by the ``url`` endpoint and the ``redirect_url``.
+    """
+    ext = _get_auth_extension(name)
+    params = await request.get_json()
+    redirect_url = params.pop("redirect_url", None)
+    flow_id = params.pop("flow_id", None)
+
+    if not redirect_url or not flow_id:
+        raise InvalidUsageException(
+            "Missing required parameters: 'redirect_url' and 'flow_id' must be provided."
+        )
+
+    flow_state = consume(flow_id)
+    if flow_state is None:
+        raise InvalidUsageException(
+            "Auth flow not found or expired. Please start a new flow."
+        )
+
+    try:
+        pkce = PkceData(**flow_state)
+    except TypeError as err:
+        raise InvalidUsageException(f"Invalid stored flow data: {err}") from err
+
+    try:
+        ext.complete_authentication(pkce, redirect_url)
+    except RuntimeError as err:
+        raise InvalidUsageException(str(err)) from err
+    return jsonify({"authenticated": True})
+
+
+def _get_auth_extensions() -> list[AuthExtension]:
+    """Return the enabled auth extensions from the registry."""
+    return [ext for ext in AUTH_EXTENSIONS if ext.is_enabled()]
+
+
+def _get_auth_extension(name: str) -> AuthExtension:
+    """Return the auth extension with the given name, or raise an exception."""
+    for ext in _get_auth_extensions():
+        if ext.name == name:
+            return ext
+    raise InvalidUsageException(f"No auth provider found with name '{name}'.")

--- a/backend/generate_types.py
+++ b/backend/generate_types.py
@@ -11,6 +11,7 @@ from beets_flask.invoker import EnqueueKind
 from beets_flask.invoker.enqueue import (
     Search,
 )
+from beets_flask.server.routes.auth import AuthFlow, AuthProviderStatus
 from beets_flask.server.routes.db_models.session import MinimalSession
 from beets_flask.server.routes.inbox import InboxStats
 from beets_flask.server.routes.library.resources import (
@@ -83,6 +84,13 @@ builder.add(AlbumResponseMinimalExpanded)
 builder.add(FolderStatusUpdate)
 builder.add(JobStatusUpdate)
 builder.add(FileSystemUpdate)
+
+
+# ---------------------------------- Auth ---------------------------------- #
+
+# Auth endpoint responses
+builder.add(AuthProviderStatus)
+builder.add(AuthFlow)
 
 
 # ---------------------------------- Config ---------------------------------- #

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -73,6 +73,23 @@ def fixture_client(testapp: Quart) -> TestClientProtocol:
     return testapp.test_client()
 
 
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Replace ``beets_flask.redis.redis_conn`` with an in-memory fake.
+
+    Note: unlike ``local_redis`` (which only mocks the rq queues), this also
+    replaces the shared connection, so code that talks to redis directly
+    (e.g. the auth flow store) works in tests.
+    """
+    from fakeredis import FakeStrictRedis
+
+    import beets_flask.redis
+
+    conn = FakeStrictRedis()
+    monkeypatch.setattr(beets_flask.redis, "redis_conn", conn)
+    return conn
+
+
 @pytest.fixture(name="runner")
 def fixture_runner(app):
     return app.test_cli_runner()

--- a/backend/tests/integration/test_routes/test_auth.py
+++ b/backend/tests/integration/test_routes/test_auth.py
@@ -1,0 +1,124 @@
+"""Tests for the auth endpoints."""
+
+from typing import ClassVar
+
+import pytest
+
+from beets_flask.extensions.auth import AuthExtension, PkceData
+from beets_flask.server.routes import auth as auth_routes
+
+PKCE = PkceData(code_verifier="verifier", state="state")
+
+
+class FakeAuth(AuthExtension):
+    """Deterministic stand-in for a real auth provider."""
+
+    name: ClassVar[str] = "fake"
+    completed_with: tuple[PkceData, str] | None = None
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        return True
+
+    def is_authenticated(self) -> bool:
+        return False
+
+    def start_authentication(self) -> tuple[PkceData, str]:
+        return PKCE, "https://example.com/authorize"
+
+    def complete_authentication(self, pkce: PkceData, redirect_url: str) -> None:
+        self.completed_with = (pkce, redirect_url)
+
+
+@pytest.fixture
+def fake_auth(monkeypatch) -> FakeAuth:
+    auth = FakeAuth()
+    monkeypatch.setattr(auth_routes, "AUTH_EXTENSIONS", [auth])
+    return auth
+
+
+class TestAuthProviders:
+    async def test_lists_provider_status(self, client, fake_auth):
+        response = await client.get("/api_v1/auth/providers")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == [{"name": "fake", "authenticated": False}]
+
+    async def test_skips_disabled_providers(self, client, monkeypatch):
+        class DisabledFake(FakeAuth):
+            @classmethod
+            def is_enabled(cls) -> bool:
+                return False
+
+        monkeypatch.setattr(auth_routes, "AUTH_EXTENSIONS", [DisabledFake()])
+
+        response = await client.get("/api_v1/auth/providers")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == []
+
+
+class TestAuthUrl:
+    async def test_returns_url_and_flow_id(self, client, fake_auth, fake_redis):
+        response = await client.get("/api_v1/auth/fake/url")
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["url"] == "https://example.com/authorize"
+        assert data["flow_id"]
+
+        # The sensitive flow state is stored server-side, not returned.
+        assert "code_verifier" not in data
+        assert "state" not in data
+
+    async def test_unknown_provider_returns_400(self, client):
+        response = await client.get("/api_v1/auth/does-not-exist/url")
+
+        assert response.status_code == 400
+
+
+class TestAuthComplete:
+    async def test_completes_authentication(self, client, fake_auth, fake_redis):
+        redirect_url = "https://example.com/callback?code=abc123"
+
+        start = await client.get("/api_v1/auth/fake/url")
+        flow = await start.get_json()
+
+        response = await client.post(
+            "/api_v1/auth/fake/complete",
+            json={"redirect_url": redirect_url, "flow_id": flow["flow_id"]},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data == {"authenticated": True}
+        assert fake_auth.completed_with == (PKCE, redirect_url)
+
+    async def test_missing_parameters_returns_400(self, client, fake_auth):
+        response = await client.post(
+            "/api_v1/auth/fake/complete", json={"redirect_url": "x"}
+        )
+        assert response.status_code == 400
+
+        response = await client.post(
+            "/api_v1/auth/fake/complete", json={"flow_id": "x"}
+        )
+        assert response.status_code == 400
+
+    async def test_unknown_flow_returns_400(self, client, fake_auth, fake_redis):
+        response = await client.post(
+            "/api_v1/auth/fake/complete",
+            json={"redirect_url": "x", "flow_id": "does-not-exist"},
+        )
+
+        assert response.status_code == 400
+
+    async def test_unknown_provider_returns_400(self, client):
+        response = await client.post(
+            "/api_v1/auth/does-not-exist/complete",
+            json={"redirect_url": "x", "flow_id": "x"},
+        )
+
+        assert response.status_code == 400

--- a/backend/tests/unit/test_extensions/test_art.py
+++ b/backend/tests/unit/test_extensions/test_art.py
@@ -15,6 +15,7 @@ from beets_flask.extensions.providers import ART_SOURCES
 from beets_flask.extensions.providers.file import FileArtSource
 from beets_flask.extensions.providers.musicbrainz import MusicbrainzArtSource
 from beets_flask.extensions.providers.spotify import SpotifyArtSource
+from beets_flask.extensions.providers.tidal import TidalArtSource
 from beets_flask.server.routes.art_preview import make_session
 
 
@@ -63,6 +64,39 @@ class TestArtResult:
         ),
         (
             "ftp://open.spotify.com/album/4zY3KmQkPOCEln8TWT9exA",
+            None,
+        ),
+        # Tidal
+        (
+            "https://tidal.com/browse/album/12345678",
+            TidalArtSource,
+        ),
+        (
+            "http://tidal.com/browse/album/12345678",
+            TidalArtSource,
+        ),
+        (
+            "https://listen.tidal.com/album/12345678",
+            TidalArtSource,
+        ),
+        (
+            "https://tidal.com/album/12345678",
+            TidalArtSource,
+        ),
+        (
+            "https://tidal.com/browse/track/12345678",
+            None,
+        ),
+        (
+            "https://tidal.com.evil.com/browse/album/12345678",
+            None,
+        ),
+        (
+            "https://evil.com/?x=tidal.com/browse/album/12345678",
+            None,
+        ),
+        (
+            "ftp://tidal.com/browse/album/12345678",
             None,
         ),
         # Musicbrainz

--- a/backend/tests/unit/test_extensions/test_tidal.py
+++ b/backend/tests/unit/test_extensions/test_tidal.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Tidal auth provider."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from beets.exceptions import UserError
+
+from beets_flask.extensions.auth import PkceData
+from beets_flask.extensions.providers.tidal import TidalAuth
+
+AUTH_URL = "https://login.tidal.com/authorize"
+TOKEN_URL = "https://auth.tidal.com/v1/oauth2/token"
+
+
+class FakeSession:
+    """Minimal stand-in for the beets tidal OAuth session."""
+
+    def __init__(self, code_verifier: str = "verifier", state: str = "state") -> None:
+        self._code_verifier = code_verifier
+        self._state = state
+        self.token: dict[str, str] | None = None
+        self.saved_token: dict[str, str] | None = None
+        self.fetch_token_kwargs: dict[str, Any] | None = None
+
+    def authorization_url(self, url: str) -> tuple[str, str]:
+        return f"{url}?code_challenge=xyz", self._state
+
+    def fetch_token(self, token_url: str, **kwargs) -> None:
+        self.fetch_token_kwargs = {"token_url": token_url, **kwargs}
+        self.token = {"access_token": "token", "refresh_token": "refresh"}
+
+    def save_token(self, token: dict[str, str]) -> None:
+        self.saved_token = token
+
+
+class FakePlugin:
+    """Minimal stand-in for beets' ``TidalPlugin``."""
+
+    def __init__(self, session: FakeSession, authenticated: bool = True) -> None:
+        self.api = SimpleNamespace(session=session)
+        self.authenticated = authenticated
+
+    def require_authentication(self) -> None:
+        if not self.authenticated:
+            raise UserError("Please login to TIDAL")
+
+
+@pytest.fixture
+def fake_plugin(monkeypatch) -> FakePlugin:
+    """Replace ``TidalAuth.tidal_plugin`` with a fake plugin instance."""
+    plugin = FakePlugin(FakeSession())
+    monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: plugin))
+    return plugin
+
+
+@pytest.fixture
+def no_plugin(monkeypatch):
+    """Make the tidal plugin unavailable."""
+    monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: None))
+
+
+class TestTidalAuth:
+    def test_start_authentication_returns_pkce_and_url(self, fake_plugin):
+        pkce, url = TidalAuth().start_authentication()
+
+        assert url == f"{AUTH_URL}?code_challenge=xyz"
+        assert pkce == PkceData(code_verifier="verifier", state="state")
+
+    def test_start_authentication_raises_without_plugin(self, no_plugin):
+        with pytest.raises(RuntimeError, match="not enabled"):
+            TidalAuth().start_authentication()
+
+    def test_complete_authentication_restores_state_and_saves_token(self, fake_plugin):
+        pkce = PkceData(code_verifier="verifier2", state="state2")
+        redirect_url = "https://example.com/callback?code=abc123"
+
+        TidalAuth().complete_authentication(pkce, redirect_url)
+
+        session = fake_plugin.api.session
+        assert session._code_verifier == "verifier2"
+        assert session._state == "state2"
+        assert session.fetch_token_kwargs == {
+            "token_url": TOKEN_URL,
+            "authorization_response": redirect_url,
+            "include_client_id": True,
+        }
+        assert session.saved_token == session.token
+
+    def test_complete_authentication_raises_without_plugin(self, no_plugin):
+        with pytest.raises(RuntimeError, match="not enabled"):
+            TidalAuth().complete_authentication(
+                PkceData(code_verifier="v", state="s"),
+                "https://example.com/callback?code=abc",
+            )
+
+    def test_is_authenticated_true_when_authenticated(self, fake_plugin):
+        assert TidalAuth().is_authenticated() is True
+
+    def test_is_authenticated_false_when_not_authenticated(self, monkeypatch):
+        plugin = FakePlugin(FakeSession(), authenticated=False)
+        monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: plugin))
+
+        assert TidalAuth().is_authenticated() is False
+
+    def test_is_authenticated_false_without_plugin(self, no_plugin):
+        assert TidalAuth().is_authenticated() is False

--- a/backend/tests/unit/test_extensions/test_tidal.py
+++ b/backend/tests/unit/test_extensions/test_tidal.py
@@ -1,13 +1,15 @@
-"""Unit tests for the Tidal auth provider."""
+"""Unit tests for the Tidal provider."""
 
 from types import SimpleNamespace
 from typing import Any
 
+import aiohttp
 import pytest
 from beets.exceptions import UserError
 
+from beets_flask.extensions.art import ArtResult
 from beets_flask.extensions.auth import PkceData
-from beets_flask.extensions.providers.tidal import TidalAuth
+from beets_flask.extensions.providers.tidal import TidalArtSource, TidalAuth
 
 AUTH_URL = "https://login.tidal.com/authorize"
 TOKEN_URL = "https://auth.tidal.com/v1/oauth2/token"
@@ -37,9 +39,20 @@ class FakeSession:
 class FakePlugin:
     """Minimal stand-in for beets' ``TidalPlugin``."""
 
-    def __init__(self, session: FakeSession, authenticated: bool = True) -> None:
-        self.api = SimpleNamespace(session=session)
+    def __init__(
+        self,
+        session: FakeSession,
+        authenticated: bool = True,
+        doc: dict | None = None,
+    ) -> None:
+        self.api = SimpleNamespace(session=session, get_albums=self._get_albums)
         self.authenticated = authenticated
+        self._doc = doc or {"data": [], "included": []}
+        self.last_get_albums_kwargs: dict[str, Any] = {}
+
+    def _get_albums(self, **kwargs) -> dict:
+        self.last_get_albums_kwargs = kwargs
+        return self._doc
 
     def require_authentication(self) -> None:
         if not self.authenticated:
@@ -105,3 +118,68 @@ class TestTidalAuth:
 
     def test_is_authenticated_false_without_plugin(self, no_plugin):
         assert TidalAuth().is_authenticated() is False
+
+
+def cover_files(*widths: int) -> list[dict]:
+    """Cover artwork files for the fake API, largest first like the real one."""
+    return [
+        {
+            "href": f"https://resources.tidal.com/images/cover-uuid/{w}x{w}.jpg",
+            "meta": {"width": w, "height": w},
+        }
+        for w in sorted(widths, reverse=True)
+    ]
+
+
+def album_doc(files: list[dict] | None = None) -> dict:
+    """Build an ``AlbumDocument``-shaped dict for the fake API."""
+    return {
+        "data": [{"id": "123", "type": "albums", "attributes": {}}],
+        "included": [
+            {
+                "id": "artwork",
+                "type": "artworks",
+                "attributes": {"files": files or []},
+            }
+        ],
+    }
+
+
+class TestTidalArtSource:
+    url = "https://tidal.com/browse/album/12345678"
+
+    @staticmethod
+    def patch_plugin(monkeypatch, doc: dict) -> FakePlugin:
+        plugin = FakePlugin(FakeSession(), doc=doc)
+        monkeypatch.setattr(TidalAuth, "tidal_plugin", classmethod(lambda cls: plugin))
+        return plugin
+
+    async def get_art(self, url: str | None = None) -> ArtResult | None:
+        async with aiohttp.ClientSession() as session:
+            return await TidalArtSource().get_art(url or self.url, session)
+
+    async def test_returns_urls_smallest_first(self, monkeypatch):
+        plugin = self.patch_plugin(
+            monkeypatch, album_doc(cover_files(1280, 750, 320, 160, 80))
+        )
+
+        result = await self.get_art()
+
+        # Tiny thumbnails (< 200px) are skipped.
+        assert result == ArtResult.from_urls(
+            [
+                "https://resources.tidal.com/images/cover-uuid/320x320.jpg",
+                "https://resources.tidal.com/images/cover-uuid/750x750.jpg",
+                "https://resources.tidal.com/images/cover-uuid/1280x1280.jpg",
+            ]
+        )
+        # The artwork must be requested explicitly.
+        assert plugin.last_get_albums_kwargs["include"] == ["coverArt"]
+
+    async def test_returns_none_without_cover(self, monkeypatch):
+        self.patch_plugin(monkeypatch, album_doc())
+
+        assert await self.get_art() is None
+
+    async def test_returns_none_without_plugin(self, no_plugin):
+        assert await self.get_art() is None

--- a/backend/tests/unit/test_redis.py
+++ b/backend/tests/unit/test_redis.py
@@ -67,3 +67,37 @@ async def test_wait_for_job_results():
     assert result is None
     assert job.result is None
     assert job.is_finished is True
+
+
+class TestStore:
+    """Tests for the generic TTL object store."""
+
+    def test_store_and_consume_roundtrip(self, fake_redis):
+        object_id = beets_flask.redis.store({"foo": "bar"})
+
+        assert object_id
+        assert beets_flask.redis.consume(object_id) == {"foo": "bar"}
+
+    def test_consume_is_single_use(self, fake_redis):
+        object_id = beets_flask.redis.store("value")
+
+        assert beets_flask.redis.consume(object_id) == "value"
+        assert beets_flask.redis.consume(object_id) is None
+
+    def test_consume_unknown_returns_none(self, fake_redis):
+        assert beets_flask.redis.consume("does-not-exist") is None
+
+    def test_default_ttl(self, fake_redis):
+        object_id = beets_flask.redis.store("value")
+        key = f"{beets_flask.redis._KEY_PREFIX}{object_id}"
+
+        # Matches the default of ``store(..., ttl=600)``.
+        ttl = fake_redis.ttl(key)
+        assert 0 < ttl <= 600
+
+    def test_custom_ttl(self, fake_redis):
+        object_id = beets_flask.redis.store("value", ttl=60)
+        key = f"{beets_flask.redis._KEY_PREFIX}{object_id}"
+
+        ttl = fake_redis.ttl(key)
+        assert 0 < ttl <= 60

--- a/docs/develop/resources/extensions.md
+++ b/docs/develop/resources/extensions.md
@@ -31,4 +31,5 @@ modular and make individual capabilities easy to extend.
 :maxdepth: 1
 
 extensions/art.md
+extensions/auth.md
 ```

--- a/docs/develop/resources/extensions/auth.md
+++ b/docs/develop/resources/extensions/auth.md
@@ -1,0 +1,42 @@
+# Auth extension
+
+The auth extension provides authentication with external services for beets
+plugins that need it. Some plugins only work after the user has authenticated
+with a service (e.g. Tidal), which normally means running a command like
+`beet tidal --auth` on the command line. The auth extension exposes the same
+flow through the `/auth` API endpoints, so authentication can happen in the
+browser from the beets-flask web UI.
+
+## How it works
+
+Authentication uses the PKCE flow (RFC 7636): the user authenticates in their
+browser, and the resulting authorization code is exchanged for a token. A
+provider implements two steps:
+
+1. `start_authentication()` returns the URL the user must visit, together with
+   sensitive flow state (the PKCE code verifier and CSRF state).
+2. After the user logs in, the service redirects back with an authorization
+   code. The caller passes the redirect URL (plus the flow state) to
+   `complete_authentication()`, which exchanges the code for a token and
+   persists it.
+
+The extension itself does not persist any state: the caller keeps the flow
+state server-side between the two steps and hands the client only an opaque
+`flow_id`. The provider is responsible for persisting the token once the flow
+is complete.
+
+## Adding a provider
+
+Providers live in `beets_flask/extensions/providers/`. A provider subclasses
+`AuthExtension` and implements `name`, `is_enabled()`, `is_authenticated()`,
+`start_authentication()` and `complete_authentication()`, then registers in
+the `AUTH_EXTENSIONS` list in `beets_flask/extensions/providers/__init__.py`.
+
+For a first example, see
+`beets_flask/extensions/providers/tidal.py`. It reuses the OAuth session of
+beets' tidal plugin to generate the authorization URL and exchange the code,
+and the plugin itself saves the resulting token.
+
+The flow state is sensitive and single-use: the code verifier must never reach
+the client, and a consumed or expired `flow_id` cannot be replayed to complete
+a flow.

--- a/docs/plugins/supported-plugins.md
+++ b/docs/plugins/supported-plugins.md
@@ -93,3 +93,11 @@ All extensions are built on beets-flask's
 
 The Art extension provides cover artwork for external release URLs. It allows
 beets-flask to show artwork previews for releases before they are imported.
+
+(auth)=
+
+### Auth
+
+Some beets plugins require you to authenticate with an external service to use them.
+The Auth extension lets them request that authentication through the beets-flask web UI,
+so you don't need to use the beets CLI directly.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,70 @@
+/** API functions and hooks for the auth endpoints (i.e. /api_v1/auth). */
+
+import {
+    queryOptions,
+    useMutation,
+    UseMutationOptions,
+    useQuery,
+} from '@tanstack/react-query';
+
+import { AuthFlow, AuthProviderStatus } from '@/pythonTypes';
+
+import { APIError, queryClient } from './common';
+
+/* -------------------------------- Queries -------------------------------- */
+
+export const authProvidersQueryOptions = () =>
+    queryOptions<AuthProviderStatus[], APIError>({
+        queryKey: ['auth', 'providers'],
+        queryFn: async () => {
+            const response = await fetch('/auth/providers');
+            return (await response.json()) as AuthProviderStatus[];
+        },
+    });
+
+/** Returns the full query result; `data` is undefined while loading or on error. */
+export const useAuthProviders = () => useQuery(authProvidersQueryOptions());
+
+/* ------------------------------- Mutations ------------------------------- */
+
+/** Start the PKCE flow: returns the URL to visit plus the single-use ``flow_id``. */
+export const startAuthMutationOptions = (
+    provider: string
+): UseMutationOptions<AuthFlow, APIError, void> => ({
+    mutationFn: async () => {
+        const response = await fetch(`/auth/${provider}/url`);
+        return (await response.json()) as AuthFlow;
+    },
+});
+
+/** Combined PKCE flow hook: ``start`` returns url + ``flow_id``, ``complete`` finishes it. */
+export const useAuth = (provider: string) => {
+    const start = useMutation(startAuthMutationOptions(provider));
+    const complete = useMutation(completeAuthMutationOptions(provider));
+    return { start, complete };
+};
+
+/** Complete the flow: exchange the redirect URL for a token, then refresh the providers. */
+export const completeAuthMutationOptions = (
+    provider: string
+): UseMutationOptions<
+    { authenticated: boolean },
+    APIError,
+    { flow_id: string; redirect_url: string }
+> => ({
+    mutationFn: async ({ flow_id, redirect_url }) => {
+        const response = await fetch(`/auth/${provider}/complete`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ flow_id, redirect_url }),
+        });
+        return (await response.json()) as { authenticated: boolean };
+    },
+    onSuccess: async () => {
+        await queryClient.invalidateQueries({
+            queryKey: ['auth', 'providers'],
+        });
+    },
+});

--- a/frontend/src/components/auth/AuthDialog.tsx
+++ b/frontend/src/components/auth/AuthDialog.tsx
@@ -1,0 +1,140 @@
+import { UserRoundKeyIcon } from 'lucide-react';
+import { useState } from 'react';
+import {
+    Button,
+    DialogContent,
+    Link,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material';
+
+import { useAuth } from '@/api/auth';
+import { Dialog } from '@/components/common/dialogs';
+import { AuthFlow } from '@/pythonTypes';
+
+/** Modal for the PKCE flow of a single provider.
+ *
+ * 1. "Open login page" starts the flow and opens the provider's login URL.
+ * 2. The user pastes the redirect URL they were sent to after logging in.
+ * 3. "Complete" exchanges the code for a token and closes the dialog.
+ */
+export function AuthDialog({
+    provider,
+    onClose,
+}: {
+    provider: string;
+    onClose: () => void;
+}) {
+    const { start, complete } = useAuth(provider);
+    const [flow, setFlow] = useState<AuthFlow | null>(null);
+    const [redirectUrl, setRedirectUrl] = useState('');
+    const [popupBlocked, setPopupBlocked] = useState(false);
+
+    const handleOpenLogin = () => {
+        start.mutate(undefined, {
+            onSuccess: (flow) => {
+                setFlow(flow);
+                setRedirectUrl('');
+                // `noopener` makes window.open() return null when the popup is
+                // blocked, in which case we offer the URL as a link instead.
+                setPopupBlocked(
+                    !window.open(flow.url, '_blank', 'noopener,noreferrer')
+                );
+            },
+        });
+    };
+
+    const handleComplete = () => {
+        if (!flow) return;
+        complete.mutate(
+            { flow_id: flow.flow_id, redirect_url: redirectUrl.trim() },
+            { onSuccess: onClose }
+        );
+    };
+
+    const error = start.error ?? complete.error;
+
+    const handleClose = (
+        _event: object,
+        reason: 'backdropClick' | 'escapeKeyDown' | 'xIconClick'
+    ) => {
+        // Don't close on backdrop clicks; the in-progress flow would be lost.
+        if (reason === 'backdropClick') return;
+        onClose();
+    };
+
+    return (
+        <Dialog
+            open
+            onClose={handleClose}
+            title={`Authenticate ${provider}`}
+            title_icon={<UserRoundKeyIcon />}
+        >
+            <DialogContent>
+                <Stack spacing={2}>
+                    <Typography variant="body2">
+                        To use {provider} as a metadata source, log in with your
+                        account:
+                    </Typography>
+                    <ol style={{ margin: 0, paddingLeft: 20 }}>
+                        <li>Click &quot;Open login page&quot; below.</li>
+                        <li>Log in and approve the access.</li>
+                        <li>
+                            You will be redirected to a page that fails to load;
+                            copy the full URL from the address bar.
+                        </li>
+                        <li>
+                            Paste it into the field below and click
+                            &quot;Complete&quot;.
+                        </li>
+                    </ol>
+                    <Button
+                        variant="contained"
+                        onClick={handleOpenLogin}
+                        disabled={start.isPending}
+                    >
+                        {start.isPending ? 'Opening...' : 'Open login page'}
+                    </Button>
+                    <TextField
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        label="Redirect URL"
+                        placeholder="https://localhost/?code=...&state=..."
+                        value={redirectUrl}
+                        onChange={(e) => setRedirectUrl(e.target.value)}
+                        disabled={complete.isPending}
+                    />
+                    {popupBlocked && flow && (
+                        <Typography variant="body2">
+                            Your browser blocked the popup. Open{' '}
+                            <Link
+                                href={flow.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                the login page
+                            </Link>{' '}
+                            manually.
+                        </Typography>
+                    )}
+                    {error && (
+                        <Typography variant="body2" color="error">
+                            {error.message}
+                        </Typography>
+                    )}
+                    <Button
+                        variant="contained"
+                        onClick={handleComplete}
+                        disabled={
+                            !flow || !redirectUrl.trim() || complete.isPending
+                        }
+                    >
+                        {complete.isPending ? 'Completing...' : 'Complete'}
+                    </Button>
+                </Stack>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/components/auth/AuthRequiredBanner.tsx
+++ b/frontend/src/components/auth/AuthRequiredBanner.tsx
@@ -1,0 +1,75 @@
+import { UserRoundKeyIcon } from 'lucide-react';
+import { useState } from 'react';
+import { Alert, AlertTitle, Box, Button, Typography } from '@mui/material';
+
+import { useAuthProviders } from '@/api/auth';
+import { AuthDialog } from '@/components/auth/AuthDialog';
+
+/** Shown when an enabled extension requires authentication.
+ *
+ * Rendered at the top of the inbox index page; not page-specific though.
+ */
+export function AuthRequiredBanner() {
+    const { data: providers, isLoading } = useAuthProviders();
+    const [authProvider, setAuthProvider] = useState<string | null>(null);
+
+    // Don't flash the banner while the providers are still loading.
+    if (isLoading) {
+        return null;
+    }
+
+    const missing = (providers ?? []).filter((p) => !p.authenticated);
+    if (missing.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <Alert
+                severity="warning"
+                icon={<UserRoundKeyIcon />}
+                sx={{ '.MuiAlert-message': { width: '100%' } }}
+            >
+                <AlertTitle>Authentication required</AlertTitle>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                    <Typography variant="body2">
+                        We detected that some metadata sources do not have valid
+                        credentials. Importing and tagging may fail or crash
+                        while such sources are enabled. Please authenticate with
+                        the following providers or disable them in your beets
+                        configuration.
+                    </Typography>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 1,
+                            marginTop: 1,
+                            justifyContent: 'center',
+                            '*': {
+                                maxWidth: '400px',
+                            },
+                        }}
+                    >
+                        {missing.map((provider) => (
+                            <Button
+                                key={provider.name}
+                                variant="outlined"
+                                onClick={() => setAuthProvider(provider.name)}
+                            >
+                                Authenticate {provider.name}
+                            </Button>
+                        ))}
+                    </Box>
+                </Box>
+            </Alert>
+            {authProvider && (
+                <AuthDialog
+                    key={authProvider}
+                    provider={authProvider}
+                    onClose={() => setAuthProvider(null)}
+                />
+            )}
+        </>
+    );
+}

--- a/frontend/src/pythonTypes.ts
+++ b/frontend/src/pythonTypes.ts
@@ -5,6 +5,7 @@
  */
 export type File = FileSystemItem;
 
+
 export interface SerializedSessionState {
     id: string;
     created_at: Date;
@@ -58,7 +59,7 @@ export interface JobStatusUpdate {
     num_jobs: number;
     job_metas: Array<JobMeta>;
     exc: SerializedException | null;
-    event: 'job_status_update';
+    event: "job_status_update";
 }
 
 export interface InboxStats {
@@ -76,7 +77,7 @@ export interface FolderStatusUpdate {
     hash: string;
     status: FolderStatus;
     exc: SerializedException | null;
-    event: 'folder_status_update';
+    event: "folder_status_update";
 }
 
 export interface Folder extends FileSystemItem {
@@ -85,7 +86,7 @@ export interface Folder extends FileSystemItem {
 
 export interface FileSystemUpdate {
     exc: SerializedException | null;
-    event: 'file_system_update';
+    event: "file_system_update";
 }
 
 export interface MatchSectionSchema {
@@ -99,9 +100,9 @@ export interface ImportDuplicateKeys {
 }
 
 export interface ImportSection {
-    duplicate_action: 'ask' | 'keep' | 'merge' | 'remove' | 'skip';
-    move: 'False';
-    copy: 'True';
+    duplicate_action: "ask" | "keep" | "merge" | "remove" | "skip";
+    move: "False";
+    copy: "True";
     duplicate_keys: ImportDuplicateKeys;
 }
 
@@ -125,7 +126,7 @@ export interface LibrarySectionSchema {
 }
 
 export interface InboxSectionSchema {
-    ignore: '_use_beets_ignore' | Array<string>;
+    ignore: "_use_beets_ignore" | Array<string>;
     debounce_before_autotag: number;
     temp_dir: string;
     folders: Record<string, InboxFolderSchema>;
@@ -136,6 +137,16 @@ export interface BeetsFlaskSchema {
     library: LibrarySectionSchema;
     terminal: TerminalSectionSchema;
     num_preview_workers: number;
+}
+
+export interface AuthProviderStatus {
+    name: string;
+    authenticated: boolean;
+}
+
+export interface AuthFlow {
+    url: string;
+    flow_id: string;
 }
 
 export interface Archive extends FileSystemItem {
@@ -246,7 +257,7 @@ export interface InboxFolderSchema {
     path: string;
     name: string;
     auto_threshold: null | number;
-    autotag: 'auto' | 'bootleg' | 'off' | 'preview';
+    autotag: "auto" | "bootleg" | "off" | "preview";
 }
 
 export interface Metadata {
@@ -352,7 +363,7 @@ export interface ItemResponse {
 }
 
 export interface MusicInfo {
-    type: 'album' | 'item' | 'track';
+    type: "album" | "item" | "track";
     artist: null | string;
     album: null | string;
     data_url: null | string;
@@ -373,7 +384,7 @@ export interface ItemInfo extends MusicInfo {
 }
 
 export interface FileSystemItem {
-    type: 'archive' | 'directory' | 'file';
+    type: "archive" | "directory" | "file";
     full_path: string;
     hash: string;
     is_album: boolean;
@@ -402,3 +413,4 @@ export interface AlbumInfo extends MusicInfo {
     catalognum: null | string;
     albumdisambig: null | string;
 }
+

--- a/frontend/src/pythonTypes.ts
+++ b/frontend/src/pythonTypes.ts
@@ -5,7 +5,6 @@
  */
 export type File = FileSystemItem;
 
-
 export interface SerializedSessionState {
     id: string;
     created_at: Date;
@@ -59,7 +58,7 @@ export interface JobStatusUpdate {
     num_jobs: number;
     job_metas: Array<JobMeta>;
     exc: SerializedException | null;
-    event: "job_status_update";
+    event: 'job_status_update';
 }
 
 export interface InboxStats {
@@ -77,7 +76,7 @@ export interface FolderStatusUpdate {
     hash: string;
     status: FolderStatus;
     exc: SerializedException | null;
-    event: "folder_status_update";
+    event: 'folder_status_update';
 }
 
 export interface Folder extends FileSystemItem {
@@ -86,7 +85,7 @@ export interface Folder extends FileSystemItem {
 
 export interface FileSystemUpdate {
     exc: SerializedException | null;
-    event: "file_system_update";
+    event: 'file_system_update';
 }
 
 export interface MatchSectionSchema {
@@ -100,9 +99,9 @@ export interface ImportDuplicateKeys {
 }
 
 export interface ImportSection {
-    duplicate_action: "ask" | "keep" | "merge" | "remove" | "skip";
-    move: "False";
-    copy: "True";
+    duplicate_action: 'ask' | 'keep' | 'merge' | 'remove' | 'skip';
+    move: 'False';
+    copy: 'True';
     duplicate_keys: ImportDuplicateKeys;
 }
 
@@ -126,7 +125,7 @@ export interface LibrarySectionSchema {
 }
 
 export interface InboxSectionSchema {
-    ignore: "_use_beets_ignore" | Array<string>;
+    ignore: '_use_beets_ignore' | Array<string>;
     debounce_before_autotag: number;
     temp_dir: string;
     folders: Record<string, InboxFolderSchema>;
@@ -257,7 +256,7 @@ export interface InboxFolderSchema {
     path: string;
     name: string;
     auto_threshold: null | number;
-    autotag: "auto" | "bootleg" | "off" | "preview";
+    autotag: 'auto' | 'bootleg' | 'off' | 'preview';
 }
 
 export interface Metadata {
@@ -363,7 +362,7 @@ export interface ItemResponse {
 }
 
 export interface MusicInfo {
-    type: "album" | "item" | "track";
+    type: 'album' | 'item' | 'track';
     artist: null | string;
     album: null | string;
     data_url: null | string;
@@ -384,7 +383,7 @@ export interface ItemInfo extends MusicInfo {
 }
 
 export interface FileSystemItem {
-    type: "archive" | "directory" | "file";
+    type: 'archive' | 'directory' | 'file';
     full_path: string;
     hash: string;
     is_album: boolean;
@@ -413,4 +412,3 @@ export interface AlbumInfo extends MusicInfo {
     catalognum: null | string;
     albumdisambig: null | string;
 }
-

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -14,6 +14,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Action, useConfig } from '@/api/config';
 import { inboxQueryOptions, walkFolder } from '@/api/inbox';
 import { ensureMinimalSessions, ensureStatuses } from '@/api/session';
+import { AuthRequiredBanner } from '@/components/auth/AuthRequiredBanner';
 import { MatchChip, StyledChip } from '@/components/common/chips';
 import { Dialog } from '@/components/common/dialogs';
 import {
@@ -99,6 +100,7 @@ function RouteComponent() {
                     flexDirection: 'column',
                 }}
             >
+                <AuthRequiredBanner />
                 <FileUploadProvider>
                     {inboxes.map((folder) => (
                         <FolderSelectionProvider key={folder.full_path}>

--- a/frontend/src/routes/version.tsx
+++ b/frontend/src/routes/version.tsx
@@ -12,6 +12,7 @@ import { Accordion } from '@mui/material';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
+import { authProvidersQueryOptions } from '@/api/auth';
 import { configYamlQueryOptions, useConfig } from '@/api/config';
 import { SourceTypeIcon } from '@/components/common/icons';
 import { PageWrapper } from '@/components/common/page';
@@ -21,6 +22,25 @@ import { VersionString } from './_frontpage';
 export const Route = createFileRoute('/version')({
     component: RouteComponent,
 });
+
+/** Shared styling so all accordions on this page look alike. */
+const accordionSx = {
+    boxShadow: 'none',
+    border: 'none',
+    outline: 'none',
+    '::before': { backgroundColor: 'unset' },
+    '.MuiAccordionSummary-content': {
+        padding: 0,
+        margin: 0,
+    },
+    button: {
+        height: 'auto',
+        padding: 0,
+        display: 'flex',
+        alignItems: 'flex-start',
+        minHeight: 'auto',
+    },
+};
 
 /** A relative simple page showing the current version */
 function RouteComponent() {
@@ -67,6 +87,7 @@ function RouteComponent() {
                     <Version />
                     <DataSources />
                     <Plugins />
+                    <Extensions />
                     <Config />
                 </Box>
             </Paper>
@@ -179,6 +200,83 @@ function Plugins() {
     );
 }
 
+function Extensions() {
+    const { data: providers } = useSuspenseQuery(authProvidersQueryOptions());
+
+    return (
+        <>
+            <Typography
+                component="label"
+                variant="caption"
+                fontWeight="bold"
+                color="textSecondary"
+            >
+                Extensions
+            </Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    maxWidth: '100%',
+                    overflow: 'hidden',
+                    gap: 1,
+                }}
+            >
+                <Accordion disableGutters sx={accordionSx}>
+                    <AccordionSummary expandIcon={<ChevronDownIcon />}>
+                        <Typography fontFamily="monospace">Auth</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                            {providers.length === 0 ? (
+                                <Typography
+                                    variant="body1"
+                                    component="span"
+                                    fontFamily="monospace"
+                                >
+                                    none enabled
+                                </Typography>
+                            ) : (
+                                providers.map((provider) => (
+                                    <Box
+                                        key={provider.name}
+                                        sx={{
+                                            display: 'flex',
+                                            gap: 1,
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="body1"
+                                            component="span"
+                                            fontFamily="monospace"
+                                        >
+                                            {provider.name}
+                                        </Typography>
+                                        <Typography
+                                            variant="body1"
+                                            component="span"
+                                            color={
+                                                provider.authenticated
+                                                    ? 'success'
+                                                    : 'error'
+                                            }
+                                        >
+                                            {provider.authenticated
+                                                ? 'authenticated'
+                                                : 'not authenticated'}
+                                        </Typography>
+                                    </Box>
+                                ))
+                            )}
+                        </Box>
+                    </AccordionDetails>
+                </Accordion>
+            </Box>
+        </>
+    );
+}
+
 function Config() {
     const theme = useTheme();
 
@@ -207,26 +305,7 @@ function Config() {
                     gap: 1,
                 }}
             >
-                <Accordion
-                    disableGutters
-                    sx={{
-                        boxShadow: 'none',
-                        border: 'none',
-                        outline: 'none',
-                        '::before': { backgroundColor: 'unset' },
-                        '.MuiAccordionSummary-content': {
-                            padding: 0,
-                            margin: 0,
-                        },
-                        button: {
-                            height: 'auto',
-                            padding: 0,
-                            display: 'flex',
-                            alignItems: 'flex-start',
-                            minHeight: 'auto',
-                        },
-                    }}
-                >
+                <Accordion disableGutters sx={accordionSx}>
                     <AccordionSummary expandIcon={<ChevronDownIcon />}>
                         <Typography fontFamily="monospace">
                             Beets configuration
@@ -249,26 +328,7 @@ function Config() {
                         </Typography>
                     </AccordionDetails>
                 </Accordion>
-                <Accordion
-                    disableGutters
-                    sx={{
-                        boxShadow: 'none',
-                        border: 'none',
-                        outline: 'none',
-                        '::before': { backgroundColor: 'unset' },
-                        '.MuiAccordionSummary-content': {
-                            padding: 0,
-                            margin: 0,
-                        },
-                        button: {
-                            height: 'auto',
-                            padding: 0,
-                            display: 'flex',
-                            alignItems: 'flex-start',
-                            minHeight: 'auto',
-                        },
-                    }}
-                >
+                <Accordion disableGutters sx={accordionSx}>
                     <AccordionSummary expandIcon={<ChevronDownIcon />} sx={{}}>
                         <Typography fontFamily="monospace">
                             Beets Flask configuration

--- a/frontend/src/routes/version.tsx
+++ b/frontend/src/routes/version.tsx
@@ -1,8 +1,10 @@
 import { ChevronDownIcon } from 'lucide-react';
+import { lazy, Suspense, useState } from 'react';
 import {
     AccordionDetails,
     AccordionSummary,
     Box,
+    Button,
     Divider,
     Paper,
     Typography,
@@ -16,8 +18,16 @@ import { authProvidersQueryOptions } from '@/api/auth';
 import { configYamlQueryOptions, useConfig } from '@/api/config';
 import { SourceTypeIcon } from '@/components/common/icons';
 import { PageWrapper } from '@/components/common/page';
+import { AuthProviderStatus } from '@/pythonTypes';
 
 import { VersionString } from './_frontpage';
+
+/** Lazily loaded so the dialog chunk is only fetched when first opened. */
+const AuthDialog = lazy(() =>
+    import('@/components/auth/AuthDialog').then((m) => ({
+        default: m.AuthDialog,
+    }))
+);
 
 export const Route = createFileRoute('/version')({
     component: RouteComponent,
@@ -33,7 +43,7 @@ const accordionSx = {
         padding: 0,
         margin: 0,
     },
-    button: {
+    '.MuiAccordionSummary-root': {
         height: 'auto',
         padding: 0,
         display: 'flex',
@@ -200,9 +210,8 @@ function Plugins() {
     );
 }
 
+/** Section listing enabled beets-flask extensions. */
 function Extensions() {
-    const { data: providers } = useSuspenseQuery(authProvidersQueryOptions());
-
     return (
         <>
             <Typography
@@ -227,52 +236,78 @@ function Extensions() {
                         <Typography fontFamily="monospace">Auth</Typography>
                     </AccordionSummary>
                     <AccordionDetails>
-                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                            {providers.length === 0 ? (
-                                <Typography
-                                    variant="body1"
-                                    component="span"
-                                    fontFamily="monospace"
-                                >
-                                    none enabled
-                                </Typography>
-                            ) : (
-                                providers.map((provider) => (
-                                    <Box
-                                        key={provider.name}
-                                        sx={{
-                                            display: 'flex',
-                                            gap: 1,
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        <Typography
-                                            variant="body1"
-                                            component="span"
-                                            fontFamily="monospace"
-                                        >
-                                            {provider.name}
-                                        </Typography>
-                                        <Typography
-                                            variant="body1"
-                                            component="span"
-                                            color={
-                                                provider.authenticated
-                                                    ? 'success'
-                                                    : 'error'
-                                            }
-                                        >
-                                            {provider.authenticated
-                                                ? 'authenticated'
-                                                : 'not authenticated'}
-                                        </Typography>
-                                    </Box>
-                                ))
-                            )}
-                        </Box>
+                        <AuthExtensions />
                     </AccordionDetails>
                 </Accordion>
             </Box>
+        </>
+    );
+}
+
+/** Auth extensions content: per-provider status with (re-)authentication. */
+function AuthExtensions() {
+    const { data: providers } = useSuspenseQuery(authProvidersQueryOptions());
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {providers.length === 0 ? (
+                <Typography
+                    variant="body1"
+                    component="span"
+                    fontFamily="monospace"
+                >
+                    none enabled
+                </Typography>
+            ) : (
+                providers.map((provider) => (
+                    <AuthProviderRow key={provider.name} provider={provider} />
+                ))
+            )}
+        </Box>
+    );
+}
+
+/** A single auth provider row: name, status and a (re-)auth button. */
+function AuthProviderRow({ provider }: { provider: AuthProviderStatus }) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                <Typography
+                    variant="body1"
+                    component="span"
+                    fontFamily="monospace"
+                >
+                    {provider.name}
+                </Typography>
+                <Typography
+                    variant="body1"
+                    component="span"
+                    color={provider.authenticated ? 'success' : 'error'}
+                >
+                    {provider.authenticated
+                        ? 'authenticated'
+                        : 'not authenticated'}
+                </Typography>
+                <Button
+                    size="small"
+                    sx={{ ml: 'auto' }}
+                    onClick={() => setOpen(true)}
+                >
+                    {provider.authenticated
+                        ? 'Re-authenticate'
+                        : 'Authenticate'}
+                </Button>
+            </Box>
+            {open && (
+                <Suspense fallback={null}>
+                    <AuthDialog
+                        provider={provider.name}
+                        onClose={() => setOpen(false)}
+                    />
+                </Suspense>
+            )}
         </>
     );
 }


### PR DESCRIPTION
Enhances support for the (relative) new tidal plugin. Should bring compatibility to the roughly same level as spotify or musicbrainz.

## Art Extension

Allow to see preview images from tidal during tagging process:
<img width="1147" height="266" alt="image" src="https://github.com/user-attachments/assets/69020973-fbdd-4627-9ce4-bc8baf22354d" />


## TODOS:

- UI Icon
- Links to tidal.com from library view
- Add to docs
