### PR TITLE
fix(importer): clear any stale exception on successful import

### DIFF
--- a/backend/beets_flask/importer/session.py
+++ b/backend/beets_flask/importer/session.py
@@ -764,21 +764,26 @@ class ImportSession(BaseSession):
 
     def finalize(self, task: importer.ImportTask):
         """
-        Reset previous match threshold exceptions.
+        Reset exceptions left over from a previous, unsuccessful attempt.
 
         Needed because we might run a normal ImportSession manually after
         the AutoImportSession. The AutoImportSession needs to keep an Exception in its
         status to inform the frontend, which we need to clear here.
         (No need to override `finalize` in AutoImportSession, despite it inherriting
         from here, because it raises when below threshold).
+
+        Reaching this point means the import succeeded, so any exception still attached
+        to the session state is stale by definition. Leaving one behind makes
+        `_get_folder_status_from_db` report the folder FAILED forever -- it overrides
+        IMPORT_COMPLETED -> IMPORTED whenever an exception is present -- which also means
+        cleanup keyed on IMPORTED never runs and the source folder is never removed.
+        This previously only cleared NotImportedException, so a session retried after a
+        DuplicateException stayed FAILED even though the album imported correctly.
         """
-        if (
-            self.state.exc is not None
-            and self.state.exc["type"] == "NotImportedException"
-            and self.state.exc["message"].startswith("Match below threshold")
-        ):
+        if self.state.exc is not None:
             log.debug(
-                "Clearing previous MatchThresholdException after successful import."
+                "Clearing previous %s after successful import.",
+                self.state.exc["type"],
             )
             self.state.exc = None
         super().finalize(task)


### PR DESCRIPTION
Fixes #346.

`ImportSession.finalize()` already existed to drop a leftover exception after a successful import,
but only matched `NotImportedException` / "Match below threshold". Every other exception survived.

Since `_get_folder_status_from_db` turns *any* attached exception into `FolderStatus.FAILED` —
overriding the `IMPORT_COMPLETED -> IMPORTED` mapping directly above it — a session that failed once
and was later retried successfully **in place** reports `FAILED` forever. The album is correctly in
the beets library, but the folder looks failed in the UI, and because beets-flask only copies during
import (#193), any cleanup keyed on `IMPORTED` never removes the source folder.

The usual trigger is the default `import.duplicate_action: ask`: the unattended attempt raises
`DuplicateException`, the user resolves it in the GUI, the import completes — and the exception stays.

Reaching `finalize()` means the import succeeded, so anything still attached is stale by definition.
This generalises the existing check rather than adding another exception type to a growing list
(there is a similar one-off for `NoCandidatesFoundException` at `session.py:615`).

### Verified on a live instance

Applied to a running v1.2.1 deployment and driven through the real API, not a unit test.

A folder parked at `WAITING_FOR_USER_SELECTION` with a `DuplicateException` attached:

```
rev=1 progress=WAITING_FOR_USER_SELECTION exc_attached=True  status=FAILED
```

then re-imported via `POST /session/enqueue` with
`kind=import_candidate, duplicate_actions={"*": "remove"}`:

```
rev=1 progress=IMPORT_COMPLETED           exc_attached=False status=IMPORTED
```

The album imported correctly (a track missing from the previous copy was also recovered). The same
run additionally cleared a stray `AttributeError` from an earlier malformed API call, which confirms
the generalisation works for exception types other than the two currently special-cased.

Before the change, that instance had 6 sessions with `progress='IMPORT_COMPLETED' AND exc IS NOT NULL`
against 346 clean — so this only affects the fail-then-retry path, but those folders never clear.

### Note on an alternative

A defensive fix in `_get_folder_status_from_db` also works and additionally repairs sessions already
stored with a stale exception:

```python
if s_state_indb.exception is not None and status != FolderStatus.IMPORTED:
```

I did not include it here, since fixing the write path seems more correct than masking it at read
time — but it may be worth adding for existing rows, which this PR alone will not repair. Happy to
add it if you would prefer both.
