### PR TITLE
fix: Get album status and minimal session data in smaller batches

### DIFF
--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -439,6 +439,14 @@ async function waitForJobUpdate({
 
 /* ----------------------------- Session status ----------------------------- */
 
+function batchFolders(items: Array<{ hash: string; path: string }>, batchSize: number): Array<Array<{ hash: string; path: string }>> {
+    const batches: Array<Array<{ hash: string; path: string }>> = [];
+    for (let start = 0; start < items.length; start += batchSize) {
+        batches.push(items.slice(start, start + batchSize));
+    }
+    return batches;
+}
+
 /** Canonical per-folder cache entry for a folder's status.
  *
  * Prefer hydrating this via `ensureStatuses` (single batch request);
@@ -481,30 +489,38 @@ export async function ensureStatuses(
         return;
     }
 
-    const params = new URLSearchParams();
-    missing.forEach((folder) => {
-        params.append('folder_hash', folder.hash);
-        params.append('folder_path', folder.path);
-    });
-    const response = await fetch(`/session/status?${params.toString()}`);
-    const statuses = (await response.json()) as FolderStatusUpdate[];
-    const byHash = new Map<string, FolderStatusUpdate>();
-    const byPath = new Map<string, FolderStatusUpdate>();
-    for (const status of statuses) {
-        if (!byHash.has(status.hash)) {
-            byHash.set(status.hash, status);
-        }
-        if (!byPath.has(status.path)) {
-            byPath.set(status.path, status);
-        }
-    }
+    const batches = batchFolders(missing, 50);
 
-    for (const folder of missing) {
-        queryClient.setQueryData<FolderStatusUpdate | null>(
-            statusQueryOptions(folder.hash, folder.path).queryKey,
-            byHash.get(folder.hash) ?? byPath.get(folder.path) ?? null
-        );
-    }
+    await Promise.all(
+        batches.map((currentBatch) => {
+            const params = new URLSearchParams();
+            currentBatch.forEach((folder) => {
+                params.append('folder_hash', folder.hash);
+                params.append('folder_path', folder.path);
+            });
+            return fetch(`/session/status?${params.toString()}`)
+                .then((response) => response.json())
+                .then((statuses: FolderStatusUpdate[]) => {
+                    const byHash = new Map<string, FolderStatusUpdate>();
+                    const byPath = new Map<string, FolderStatusUpdate>();
+                    for (const status of statuses) {
+                        if (!byHash.has(status.hash)) {
+                            byHash.set(status.hash, status);
+                        }
+                        if (!byPath.has(status.path)) {
+                            byPath.set(status.path, status);
+                        }
+                    }
+
+                    for (const folder of currentBatch) {
+                        queryClient.setQueryData<FolderStatusUpdate | null>(
+                            statusQueryOptions(folder.hash, folder.path).queryKey,
+                            byHash.get(folder.hash) ?? byPath.get(folder.path) ?? null
+                        );
+                    }
+                });
+        })
+    );
 }
 
 /* -------------------------- Minimal session info -------------------------- */
@@ -544,6 +560,8 @@ export const minimalSessionQueryOptions = (
     },
 });
 
+
+
 /**
  * Fetch minimal chip info for many folders in one request and populate their
  * canonical cache entries. Skips cached folders; caches null for folders
@@ -561,20 +579,27 @@ export async function ensureMinimalSessions(
 
     if (missing.length === 0) {
         return;
-    }
+    }       
 
-    const params = new URLSearchParams();
-    missing.forEach((folder) => {
-        params.append('folder_hash', folder.hash);
-        params.append('folder_path', folder.path);
-    });
-    const response = await fetch(`/session/minimal?${params.toString()}`);
-    const res = (await response.json()) as Record<string, MinimalSession>;
+    const batches = batchFolders(missing, 50);
 
-    missing.forEach((folder) => {
-        queryClient.setQueryData<MinimalSession | null>(
-            minimalSessionQueryOptions(folder.hash, folder.path).queryKey,
-            res[folder.hash] ?? null
-        );
-    });
+    await Promise.all(
+        batches.map((currentBatch) => {
+            const params = new URLSearchParams();
+            currentBatch.forEach((folder) => {
+                params.append('folder_hash', folder.hash);
+                params.append('folder_path', folder.path);
+            });
+            return fetch(`/session/minimal?${params.toString()}`)
+                .then((response) => response.json())
+                .then((res: Record<string, MinimalSession>) => {
+                    currentBatch.forEach((folder) => {
+                        queryClient.setQueryData<MinimalSession | null>(
+                            minimalSessionQueryOptions(folder.hash, folder.path).queryKey,
+                            res[folder.hash] ?? null
+                        );
+                    });
+                });
+        })
+    );
 }

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -46,14 +46,14 @@ export const Route = createFileRoute('/inbox/')({
         // Filter: all top level folders/archives in inboxes
         const prefetch_folders: Array<Folder | Archive> = [];
         for (const inbox of inboxes) {
-            for (const child of walkFolder(inbox, 1)) {
+            for (const child of walkFolder(inbox)) {
                 if (child.type === 'directory' || child.type === 'archive') {
                     prefetch_folders.push(child);
                 }
             }
         }
 
-        const batchSize = 100;
+        const batchSize = 50;
         const batches: Array<Array<Folder | Archive>> = [];
 
         for (

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -52,22 +52,35 @@ export const Route = createFileRoute('/inbox/')({
                 }
             }
         }
+
+        const batchSize = 100;
+        const batches: Array<Array<Folder | Archive>> = [];
+
+        for (
+            let start = 0;
+            start < prefetch_folders.length;
+            start += batchSize
+        ) {
+            batches.push(
+                prefetch_folders.slice(start, start + batchSize)
+            );
+        }
+
         // Prefetch minimal information for all sessions within the top level inbox
-        // folders. This prevents waterfall loading states
-        await Promise.all([
-            ensureStatuses(
-                prefetch_folders.map((f) => ({
-                    hash: f.hash,
-                    path: f.full_path,
-                }))
-            ),
-            ensureMinimalSessions(
-                prefetch_folders.map((f) => ({
-                    hash: f.hash,
-                    path: f.full_path,
-                }))
-            ),
-        ]);
+        // folders. This prevents waterfall loading states.
+        await Promise.all(
+            batches.map((currentBatch) => {
+                const folders = currentBatch.map((folder) => ({
+                    hash: folder.hash,
+                    path: folder.full_path,
+                }));
+
+                return Promise.all([
+                    ensureStatuses(folders),
+                    ensureMinimalSessions(folders),
+                ]);
+            })
+        );
     },
 });
 

--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -46,41 +46,28 @@ export const Route = createFileRoute('/inbox/')({
         // Filter: all top level folders/archives in inboxes
         const prefetch_folders: Array<Folder | Archive> = [];
         for (const inbox of inboxes) {
-            for (const child of walkFolder(inbox)) {
+            for (const child of walkFolder(inbox, 1)) {
                 if (child.type === 'directory' || child.type === 'archive') {
                     prefetch_folders.push(child);
                 }
             }
         }
-
-        const batchSize = 50;
-        const batches: Array<Array<Folder | Archive>> = [];
-
-        for (
-            let start = 0;
-            start < prefetch_folders.length;
-            start += batchSize
-        ) {
-            batches.push(
-                prefetch_folders.slice(start, start + batchSize)
-            );
-        }
-
         // Prefetch minimal information for all sessions within the top level inbox
-        // folders. This prevents waterfall loading states.
-        await Promise.all(
-            batches.map((currentBatch) => {
-                const folders = currentBatch.map((folder) => ({
-                    hash: folder.hash,
-                    path: folder.full_path,
-                }));
-
-                return Promise.all([
-                    ensureStatuses(folders),
-                    ensureMinimalSessions(folders),
-                ]);
-            })
-        );
+        // folders. This prevents waterfall loading states
+        await Promise.all([
+            ensureStatuses(
+                prefetch_folders.map((f) => ({
+                    hash: f.hash,
+                    path: f.full_path,
+                }))
+            ),
+            ensureMinimalSessions(
+                prefetch_folders.map((f) => ({
+                    hash: f.hash,
+                    path: f.full_path,
+                }))
+            ),
+        ]);
     },
 });
 


### PR DESCRIPTION
Greetings, gentlemen and gentlewomen.

Fixed: #352

As @semohr suggested, this PR makes requests to status and minimal in smaller batches, preventing the issue of exceeding the enforced 16 KB HTTP request-header limit.

I set the batch size to a hard-coded limit of 50 sets of hashes and paths. With my library, the headers of each request now average around 6 KB. This can vary depending on the folder structure and the size of the user’s inbox library. If a directory has too many characters or too many levels, 50 might be too large for those edge cases, but the limit can be reduced with a one-line change.

I also fixed an issue where, even after the batch requests were made, each folder in the inbox still made an individual status and minimal session request.