### PR TITLE
propose: include different folders in batch request

### DIFF
--- a/frontend/src/routes/inbox/index.tsx
+++ b/frontend/src/routes/inbox/index.tsx
@@ -46,7 +46,7 @@ export const Route = createFileRoute('/inbox/')({
         // Filter: all top level folders/archives in inboxes
         const prefetch_folders: Array<Folder | Archive> = [];
         for (const inbox of inboxes) {
-            for (const child of walkFolder(inbox, 1)) {
+            for (const child of walkFolder(inbox, Infinity)) {
                 if (child.type === 'directory' || child.type === 'archive') {
                     prefetch_folders.push(child);
                 }


### PR DESCRIPTION
Greetings, gentlemen and gentlewomen.

I accidentally opened a can of worms in my previous pr, but I'm pretty sure you guys wont find anything new here.

I want to address some things before i begin:

1st. 
I was wrong about this: 
>each folder in the inbox still made an individual status and minimal session request

and my responses in the review of @semohr 

it still makes the additional requests, not of each folder, but rather of each directory not in the first 2 layers. The 2nd point explains it further. 

2nd
Having `walkFolder(inbox, 1)` only fetches the first 2 layers of the inbox library, including the inbox folder itself. I'll demonstrate with my inbox.

My inbox directory look like this:
`Inbox folder -> artist -> album -> audio files`

So `walkFolder(inbox, 1)` only added the hashes and paths of 'Inbox folder' and 'artist'. 

So with my inbox setup, not a single album is fetched in the initial batch, that's why i thought it was an error. So putting `walkFolder(inbox, 2)` fixes the issue in my inbox. But every user has a different setup, so in my opinion there is no correct number.

3rd
Removing the number or just putting Infinity, doesn't add folder files to the initial batch thanks to this these lines:
```
if (child.type === 'directory' || child.type === 'archive') {
    prefetch_folders.push(child);
}
```
But it adds every directory to the initial batch, which I'm not sure its the intention.

---

Based on this, not sure what's the way to go, I understand that my inbox library is an edge case, but having `walkFolder(inbox, 1)` makes a bunch of requests that essentially do nothing.

I guess the best of both worlds, without adding complexity,  would be something like this:

For the bulk requests, it only adds detected albums to the list.
```
for (const child of walkFolder(inbox)) {
    if (child.is_album) {
        prefetch_folders.push(child);
    }
}
```

This alone fixes minimal session, but not status.

This function still analyzes every directory in the tree:

```
function useImportedFolders(folder: Folder) {
    const folders = useMemo(
        () =>
            [...walkFolder(folder)].filter(
                (f) => f.type !== 'file' && f.full_path !== folder.full_path
            ),
        [folder]
    );

    const statuses = useQueries({
        queries: folders.map((f) => statusQueryOptions(f.hash, f.full_path)),
    });

    return folders.filter(
        (f, i) => statuses[i].data?.status === FolderStatus.IMPORTED
    );
}
```

so just changing:
```
[...walkFolder(folder)].filter(
    (f) => f.type !== 'file' && f.full_path !== folder.full_path
),
```

to: 
```
[...walkFolder(folder)].filter(
    (f) => f.is_album
),
```

Does the trick, but you guys don't seem to use the is_album attribute in many places, so I'm not betting my chips on these fixes.

what do you guys think?

            